### PR TITLE
Exclude removed packages from workspace index on new scan

### DIFF
--- a/webapp/db-migrations/migrations/20220920172129-add-indexes.js
+++ b/webapp/db-migrations/migrations/20220920172129-add-indexes.js
@@ -2,7 +2,7 @@ module.exports = {
     async up(db, client) {
         const analysesCollection = db.collection("analyses");
         await analysesCollection.createIndex(["workspace"], { name: "workspace_1" });
-        await analysesCollection.createIndex(["workspace", "_id"], { name: "workspace_id_1" });
+        await analysesCollection.createIndex(["workspace", "_id"], { name: "workspace_1_id_1" });
 
         const authRequestsCollection = db.collection("authRequests");
         await authRequestsCollection.createIndex({ "createdAt": 1 }, { name: "ttl", expireAfterSeconds: 1800 });
@@ -62,6 +62,7 @@ module.exports = {
     async down(db, client) {
         const analysesCollection = db.collection("analyses");
         await analysesCollection.dropIndex("workspace_1");
+        await analysesCollection.dropIndex("workspace_1_id_1");
 
         const authRequestsCollection = db.collection("authRequests");
         await authRequestsCollection.dropIndex("ttl");

--- a/webapp/db-migrations/migrations/20220920172129-add-indexes.js
+++ b/webapp/db-migrations/migrations/20220920172129-add-indexes.js
@@ -2,6 +2,7 @@ module.exports = {
     async up(db, client) {
         const analysesCollection = db.collection("analyses");
         await analysesCollection.createIndex(["workspace"], { name: "workspace_1" });
+        await analysesCollection.createIndex(["workspace", "_id"], { name: "workspace_id_1" });
 
         const authRequestsCollection = db.collection("authRequests");
         await authRequestsCollection.createIndex({ "createdAt": 1 }, { name: "ttl", expireAfterSeconds: 1800 });

--- a/webapp/src/backend/service/analysis/analysis.ts
+++ b/webapp/src/backend/service/analysis/analysis.ts
@@ -155,7 +155,7 @@ export async function performPostAnalysisOperations(
     return withAnalysisWriteLock(
         workspace.id,
         async () => {
-            const analysisIdsByPackage = await getLatestAnalysisIdsForAllPackageNames(workspace.id, {
+            const analysisIdsByPackage = await getLatestAnalysisIdsForActivePackages(workspace.id, {
                 onOrBefore: analysis.createdAt,
             });
 
@@ -295,7 +295,7 @@ export async function getAnalysesOf(
     };
 }
 
-export async function getLatestAnalysisIdsForAllPackageNames(
+export async function getLatestAnalysisIdsForActivePackages(
     workspaceId: string,
     params: { onOrBefore?: Date; } = {},
 ): Promise<Record<string, MongooseTypes.ObjectId>> {
@@ -330,8 +330,8 @@ export async function getLatestAnalysisIdsForAllPackageNames(
     for (const analysis of analyses) {
         const repo = analysis.repository;
 
-        // Find if this analysis matches any existing repository group
-        let matchedGroup: RepoGroup | undefined;
+        // Find all existing repository groups that match this analysis's metadata
+        const matchedGroups: RepoGroup[] = [];
 
         if (repo) {
             const scopeAndName = repo.scope && repo.name ? `${repo.scope}/${repo.name}` : undefined;
@@ -342,13 +342,40 @@ export async function getLatestAnalysisIdsForAllPackageNames(
                     (repo.url && group.urls.has(repo.url)) ||
                     (repo.initialCommitHash && group.commitHashes.has(repo.initialCommitHash))
                 ) {
-                    matchedGroup = group;
-                    break;
+                    matchedGroups.push(group);
                 }
             }
         }
 
-        if (!matchedGroup) {
+        let matchedGroup: RepoGroup;
+
+        if (matchedGroups.length > 0) {
+            // Use the first matched group as canonical
+            matchedGroup = matchedGroups[0];
+
+            // If there are multiple matching groups, merge them all into the first one
+            if (matchedGroups.length > 1) {
+                for (let i = 1; i < matchedGroups.length; i++) {
+                    const otherGroup = matchedGroups[i];
+
+                    for (const sn of otherGroup.scopesAndNames) {
+                        matchedGroup.scopesAndNames.add(sn);
+                    }
+                    for (const url of otherGroup.urls) {
+                        matchedGroup.urls.add(url);
+                    }
+                    for (const hash of otherGroup.commitHashes) {
+                        matchedGroup.commitHashes.add(hash);
+                    }
+
+                    const index = groups.indexOf(otherGroup);
+                    if (index > -1) {
+                        groups.splice(index, 1);
+                    }
+                }
+            }
+        } else {
+            // Create a new repository group
             matchedGroup = {
                 scopesAndNames: new Set<string>(),
                 urls: new Set<string>(),
@@ -356,7 +383,6 @@ export async function getLatestAnalysisIdsForAllPackageNames(
                 latestAnalysisId: analysis._id,
                 latestPackageNames: analysis.packageNames,
             };
-
             groups.push(matchedGroup);
         }
 
@@ -379,7 +405,10 @@ export async function getLatestAnalysisIdsForAllPackageNames(
     const map: Record<string, MongooseTypes.ObjectId> = {};
     for (const group of groups) {
         for (const packageName of group.latestPackageNames) {
-            map[packageName] = group.latestAnalysisId;
+            const currentLatestId = map[packageName];
+            if (!currentLatestId || group.latestAnalysisId.getTimestamp() > currentLatestId.getTimestamp()) {
+                map[packageName] = group.latestAnalysisId;
+            }
         }
     }
     return map;
@@ -414,7 +443,7 @@ export async function deleteAnalysis(
 
             const indexDocsToRecreate = await findUniqueComponentIndexesByAnalysisId<keyof FieldFilter>(workspaceId, analysisId, { fields });
             for (const doc of indexDocsToRecreate) {
-                const analysisIdsByPackage = await getLatestAnalysisIdsForAllPackageNames(workspaceId, {
+                const analysisIdsByPackage = await getLatestAnalysisIdsForActivePackages(workspaceId, {
                     onOrBefore: doc.analyzedAt,
                 });
 
@@ -505,7 +534,7 @@ export async function deleteAnalyses(
             );
 
             for (const doc of relevantIndexDocs) {
-                const analysisIdsByPackage = await getLatestAnalysisIdsForAllPackageNames(workspaceId, {
+                const analysisIdsByPackage = await getLatestAnalysisIdsForActivePackages(workspaceId, {
                     onOrBefore: doc.analyzedAt,
                 });
 

--- a/webapp/src/backend/service/analysis/analysis.ts
+++ b/webapp/src/backend/service/analysis/analysis.ts
@@ -295,74 +295,91 @@ export async function getAnalysesOf(
     };
 }
 
-export async function getLatestAnalysisIdsForAllPackageNames(workspaceId: string, params: { onOrBefore?: Date; } = {}): Promise<Record<string, MongooseTypes.ObjectId>> {
-    const result = await AnalysisModel.aggregate<{ latestAnalysisId: MongooseTypes.ObjectId; latestPackageNames: string[]; }>(
-        [
-            {
-                $match: {
-                    workspace: new MongooseTypes.ObjectId(workspaceId),
-                    ...(params.onOrBefore ? ({ createdAt: { $lte: params.onOrBefore } }) : {}),
-                },
-            },
-            {
-                $sort: {
-                    _id: 1,
-                },
-            },
-            {
-                $group: {
-                    _id: {
-                        $cond: {
-                            if: {
-                                $and: [
-                                    { $ne: ["$repository.scope", null] },
-                                    { $ne: ["$repository.name", null] },
-                                    { $ne: ["$repository.scope", ""] },
-                                    { $ne: ["$repository.name", ""] },
-                                ],
-                            },
-                            then: { $concat: ["$repository.scope", "/", "$repository.name"] },
-                            else: {
-                                $cond: {
-                                    if: {
-                                        $and: [
-                                            { $ne: ["$repository.url", null] },
-                                            { $ne: ["$repository.url", ""] },
-                                        ],
-                                    },
-                                    then: "$repository.url",
-                                    else: {
-                                        $cond: {
-                                            if: {
-                                                $and: [
-                                                    { $ne: ["$repository.initialCommitHash", null] },
-                                                    { $ne: ["$repository.initialCommitHash", ""] },
-                                                ],
-                                            },
-                                            then: "$repository.initialCommitHash",
-                                            else: "$_id",
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                    latestAnalysisId: {
-                        $last: "$_id",
-                    },
-                    latestPackageNames: {
-                        $last: "$packageNames",
-                    },
-                },
-            },
-        ],
-        { readPreference: mongoose.mongo.ReadPreference.PRIMARY }
-    );
+export async function getLatestAnalysisIdsForAllPackageNames(
+    workspaceId: string,
+    params: { onOrBefore?: Date; } = {},
+): Promise<Record<string, MongooseTypes.ObjectId>> {
+    const analyses = await AnalysisModel.find(
+        {
+            workspace: new MongooseTypes.ObjectId(workspaceId),
+            ...(params.onOrBefore ? { createdAt: { $lte: params.onOrBefore } } : {}),
+        },
+        {
+            _id: 1,
+            packageNames: 1,
+            repository: 1,
+        },
+        {
+            readPreference: mongoose.mongo.ReadPreference.PRIMARY,
+        },
+    )
+        .sort({ _id: 1 })
+        .lean()
+        .exec();
+
+    interface RepoGroup {
+        scopesAndNames: Set<string>;
+        urls: Set<string>;
+        commitHashes: Set<string>;
+        latestAnalysisId: MongooseTypes.ObjectId;
+        latestPackageNames: string[];
+    }
+
+    const groups: RepoGroup[] = [];
+
+    for (const analysis of analyses) {
+        const repo = analysis.repository;
+
+        // Find if this analysis matches any existing repository group
+        let matchedGroup: RepoGroup | undefined;
+
+        if (repo) {
+            const scopeAndName = repo.scope && repo.name ? `${repo.scope}/${repo.name}` : undefined;
+
+            for (const group of groups) {
+                if (
+                    (scopeAndName && group.scopesAndNames.has(scopeAndName)) ||
+                    (repo.url && group.urls.has(repo.url)) ||
+                    (repo.initialCommitHash && group.commitHashes.has(repo.initialCommitHash))
+                ) {
+                    matchedGroup = group;
+                    break;
+                }
+            }
+        }
+
+        if (!matchedGroup) {
+            matchedGroup = {
+                scopesAndNames: new Set<string>(),
+                urls: new Set<string>(),
+                commitHashes: new Set<string>(),
+                latestAnalysisId: analysis._id,
+                latestPackageNames: analysis.packageNames,
+            };
+
+            groups.push(matchedGroup);
+        }
+
+        if (repo) {
+            if (repo.scope && repo.name) {
+                matchedGroup.scopesAndNames.add(`${repo.scope}/${repo.name}`);
+            }
+            if (repo.url) {
+                matchedGroup.urls.add(repo.url);
+            }
+            if (repo.initialCommitHash) {
+                matchedGroup.commitHashes.add(repo.initialCommitHash);
+            }
+        }
+
+        matchedGroup.latestAnalysisId = analysis._id;
+        matchedGroup.latestPackageNames = analysis.packageNames;
+    }
 
     const map: Record<string, MongooseTypes.ObjectId> = {};
-    for (const record of result) {
-        for (const packageName of record.latestPackageNames) {
-            map[packageName] = record.latestAnalysisId;
+    for (const group of groups) {
+        for (const packageName of group.latestPackageNames) {
+            map[packageName] = group.latestAnalysisId;
         }
     }
     return map;

--- a/webapp/src/backend/service/analysis/analysis.ts
+++ b/webapp/src/backend/service/analysis/analysis.ts
@@ -296,7 +296,7 @@ export async function getAnalysesOf(
 }
 
 export async function getLatestAnalysisIdsForAllPackageNames(workspaceId: string, params: { onOrBefore?: Date; } = {}): Promise<Record<string, MongooseTypes.ObjectId>> {
-    const result = await AnalysisModel.aggregate<{ _id: string; latestAnalysisId: string; }>(
+    const result = await AnalysisModel.aggregate<{ latestAnalysisId: MongooseTypes.ObjectId; latestPackageNames: string[]; }>(
         [
             {
                 $match: {
@@ -305,13 +305,53 @@ export async function getLatestAnalysisIdsForAllPackageNames(workspaceId: string
                 },
             },
             {
-                $unwind: "$packageNames",
+                $sort: {
+                    _id: 1,
+                },
             },
             {
                 $group: {
-                    _id: "$packageNames",
+                    _id: {
+                        $cond: {
+                            if: {
+                                $and: [
+                                    { $ne: ["$repository.scope", null] },
+                                    { $ne: ["$repository.name", null] },
+                                    { $ne: ["$repository.scope", ""] },
+                                    { $ne: ["$repository.name", ""] },
+                                ],
+                            },
+                            then: { $concat: ["$repository.scope", "/", "$repository.name"] },
+                            else: {
+                                $cond: {
+                                    if: {
+                                        $and: [
+                                            { $ne: ["$repository.url", null] },
+                                            { $ne: ["$repository.url", ""] },
+                                        ],
+                                    },
+                                    then: "$repository.url",
+                                    else: {
+                                        $cond: {
+                                            if: {
+                                                $and: [
+                                                    { $ne: ["$repository.initialCommitHash", null] },
+                                                    { $ne: ["$repository.initialCommitHash", ""] },
+                                                ],
+                                            },
+                                            then: "$repository.initialCommitHash",
+                                            else: "$_id",
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
                     latestAnalysisId: {
-                        $max: "$_id",
+                        $last: "$_id",
+                    },
+                    latestPackageNames: {
+                        $last: "$packageNames",
                     },
                 },
             },
@@ -319,9 +359,13 @@ export async function getLatestAnalysisIdsForAllPackageNames(workspaceId: string
         { readPreference: mongoose.mongo.ReadPreference.PRIMARY }
     );
 
-    return result.reduce((map, record) =>
-        ({ ...map, [record._id]: new MongooseTypes.ObjectId(record.latestAnalysisId) })
-    , {});
+    const map: Record<string, MongooseTypes.ObjectId> = {};
+    for (const record of result) {
+        for (const packageName of record.latestPackageNames) {
+            map[packageName] = record.latestAnalysisId;
+        }
+    }
+    return map;
 }
 
 export async function deleteAnalysis(

--- a/webapp/src/backend/service/dataIssues/dataIssues.ts
+++ b/webapp/src/backend/service/dataIssues/dataIssues.ts
@@ -3,7 +3,7 @@ import { Types as MongooseTypes } from "mongoose";
 import { type InvalidDependency } from "../../../cliDataModels/InvalidDependency";
 import { FilterOperation } from "../../../common/models/FilterOperation";
 import { BaseError } from "../../error";
-import { getAnalysesOf, getLatestAnalysisIdsForAllPackageNames } from "../analysis/analysis";
+import { getAnalysesOf, getLatestAnalysisIdsForActivePackages } from "../analysis/analysis";
 import { getLatestComponentsIn, RESERVED_TAGS } from "../component/component";
 import { logException } from "../logger";
 import { type Workspace, type Project } from "../workspace/workspace";
@@ -89,7 +89,7 @@ export async function getDataIssues(workspace: Workspace): Promise<DataIssue[]> 
             new DataIssue(p, [], new Set()),
         ])
     );
-    const analysisIdMap = await getLatestAnalysisIdsForAllPackageNames(workspace.id);
+    const analysisIdMap = await getLatestAnalysisIdsForActivePackages(workspace.id);
     const analysisIds = Object.values(analysisIdMap);
 
     if (Object.values(analysisIdMap).length === 0) {

--- a/webapp/tests/backend/createAnalyses/createAnalyses.test.ts
+++ b/webapp/tests/backend/createAnalyses/createAnalyses.test.ts
@@ -173,4 +173,25 @@ describe("Create analyses", () => {
             updatedAt: expect.any(Date),
         }, "7. Workspace");
     });
+
+    it("should exclude removed packages from the workspace index when a new scan is submitted", async () => {
+        const modifiedPayload = JSON.parse(
+            JSON.stringify(omletWebapp).replace(/@omlet\/webapp/g, "@omlet/new-package"),
+        ) as Record<string, unknown>;
+
+        const res = await request(app)
+            .post(`/api/workspaces/${workspaceSlug}/analyses`)
+            .set("Cookie", `omlet-auth-token=${token}`)
+            .send(modifiedPayload);
+
+        expect(res.status).toBe(httpStatus.OK);
+        // Wait for post-analysis background tasks to complete (indexes, projects update)
+        await new Promise(resolve => setTimeout(resolve, 10000));
+
+        const workspace = await WorkspaceModel.findOne({ _id: workspaceId }, {}, { lean: true });
+        const packageNames = workspace?.projects.map((p: any) => p.packageName) ?? [];
+
+        expect(packageNames).toContain("@omlet/new-package");
+        expect(packageNames).not.toContain("@omlet/webapp");
+    });
 });

--- a/webapp/tests/setup.ts
+++ b/webapp/tests/setup.ts
@@ -1,5 +1,7 @@
 jest.setTimeout(30000); // sets the timeout to 30 seconds
 
+import { config } from "dotenv";
+config({ path: "./.env.test" });
 
 import { close as closeDb, init as initDb } from "./helper/db/mongo";
 import { close as closeCache, init as initCache } from "./helper/db/redis";


### PR DESCRIPTION
Group analyses in `getLatestAnalysisIdsForAllPackageNames` by repository instead of aggregating over all scans globally. The sequence of repository grouping: `scope/name` -> `url` -> `initialCommitHash` -> `_id`.

Fixes #3 