### PR TITLE
Add "break down by custom property" to analytics

### DIFF
--- a/webapp/src/backend/router/schema.ts
+++ b/webapp/src/backend/router/schema.ts
@@ -235,7 +235,13 @@ const baseDataAnalysisSchema = joi.object({
 const conditionalCustomPropertySchema = joi.string().when("analysisSubject", {
     is: AnalysisSubject.CustomProperties,
     then: joi.required(),
-    otherwise: joi.forbidden(),
+    // When not analyzing a custom property, the field is only allowed if we're
+    // breaking down by one (e.g. analyze Projects, break down by "DS Version").
+    otherwise: joi.when("breakdownType", {
+        is: BreakdownType.CustomProperty,
+        then: joi.optional(),
+        otherwise: joi.forbidden(),
+    }),
 });
 
 export const latestDataAnalysisSchema = baseDataAnalysisSchema.keys({

--- a/webapp/src/backend/service/component/dataTransformer.ts
+++ b/webapp/src/backend/service/component/dataTransformer.ts
@@ -123,7 +123,7 @@ function getChartDatumLink({
     }
 }
 
-function getChartValueLink(analysisSubject: AnalysisSubject, breakdownType: BreakdownType, datumLink: string, barId: string) {
+function getChartValueLink(analysisSubject: AnalysisSubject, breakdownType: BreakdownType, datumLink: string, barId: string, customProperty?: string) {
     if (analysisSubject === AnalysisSubject.Components) {
         switch (breakdownType) {
             case BreakdownType.ProjectUsedIn:
@@ -159,6 +159,17 @@ function getChartValueLink(analysisSubject: AnalysisSubject, breakdownType: Brea
                     value: [barId],
                 });
             }
+        case BreakdownType.CustomProperty:
+            if (!customProperty || barId === ReservedCustomPropertyValue.NotSet) {
+                return datumLink;
+            }
+            return appendFilter(datumLink, {
+                type: FilterType.CustomProperty,
+                field: `metadata.${customProperty}`,
+                operation: FilterOperation.Equals,
+                dataType: FilterDataType.String,
+                value: [barId],
+            });
         case undefined:
         default:
             return datumLink;
@@ -186,6 +197,8 @@ function getBreakdownTypeGroupKey(breakdownType: BreakdownType): keyof DataAnaly
             return "parentPackageName";
         case BreakdownType.Tag:
             return "childTag";
+        case BreakdownType.CustomProperty:
+            return "parentCustomProperty";
     }
 }
 
@@ -279,6 +292,8 @@ function groupByBreakdownType(analyses: DataAnalysis[], breakdownType: Breakdown
                 return ReservedProjectName.None;
             } else if (breakdownType === BreakdownType.Tag) {
                 return RESERVED_TAGS.UNTAGGED.slug;
+            } else if (breakdownType === BreakdownType.CustomProperty) {
+                return ReservedCustomPropertyValue.NotSet;
             }
         }
 
@@ -381,6 +396,7 @@ function transformBrokenDownLatestDataAnalysis(
     analysisSubject: AnalysisSubject,
     breakdownType: BreakdownType,
     datumLink?: string,
+    customProperty?: string,
 ): ChartValue[] {
     let values: ChartValue[];
 
@@ -429,6 +445,28 @@ function transformBrokenDownLatestDataAnalysis(
 
             values.sort((a, b) => compareTag(tagMap[a.id], tagMap[b.id]));
             break;
+        case BreakdownType.CustomProperty:
+            values = Object.entries(brokenDownDataAnalyses)
+                .map(([propertyValue, analyses]) => ({
+                    id: propertyValue,
+                    name: propertyValue === ReservedCustomPropertyValue.NotSet ? "(not set)" : propertyValue,
+                    link: datumLink && getChartValueLink(analysisSubject, breakdownType, datumLink, propertyValue, customProperty),
+                    value: findSumOfUsageCount(analyses),
+                }));
+
+            values.sort((a, b) => {
+                if (a.id === ReservedCustomPropertyValue.NotSet) {
+                    return 1;
+                }
+                if (b.id === ReservedCustomPropertyValue.NotSet) {
+                    return -1;
+                }
+                if (a.value === b.value) {
+                    return compareString(a.name, b.name);
+                }
+                return b.value - a.value;
+            });
+            break;
     }
 
     return values;
@@ -463,7 +501,7 @@ function transformLatestDataWithBreakdown({
     return Object.entries(latestDataAnalysisWithBreakdown).map(([key, brokenDownDataAnalyses]): ChartDatum => {
         const { id: datumId, name: label } = getChartValueData(key, componentMap, projectMap, tagMap, analysisSubject);
         const link = getChartDatumLink({ analysisSubject, customProperty, workspaceSlug, label, id: key });
-        const values = transformBrokenDownLatestDataAnalysis(brokenDownDataAnalyses, projectMap, tagMap, analysisSubject, breakdownType, link);
+        const values = transformBrokenDownLatestDataAnalysis(brokenDownDataAnalyses, projectMap, tagMap, analysisSubject, breakdownType, link, customProperty);
 
         return {
             id: datumId,

--- a/webapp/src/backend/service/savedChart/savedChart.ts
+++ b/webapp/src/backend/service/savedChart/savedChart.ts
@@ -2,7 +2,7 @@ import { type UpdateQuery } from "mongoose";
 
 import { AnalysisSubject } from "../../../common/models/AnalysisSubject";
 import { AnalysisType } from "../../../common/models/AnalysisType";
-import { type BreakdownType } from "../../../common/models/BreakdownType";
+import { BreakdownType } from "../../../common/models/BreakdownType";
 import { type Filter } from "../../../common/models/Filter";
 import { type TimeSeriesFilter } from "../../../common/models/TimeSeriesFilter";
 import { ServiceError } from "../error";
@@ -208,16 +208,19 @@ export async function updateSavedChart(workspace: Workspace, savedChartSlug: str
     }
 
     if (analysisSubject !== undefined) {
-        if (analysisSubject === AnalysisSubject.CustomProperties) {
-            updates.$set ??= {};
-            updates.$set.customProperty = customProperty;
+        updates.$set ??= {};
+        updates.$set.analysisSubject = analysisSubject;
+
+        // The custom property is needed both when analyzing a custom property and
+        // when breaking down by one — only clear it when neither applies.
+        if (analysisSubject === AnalysisSubject.CustomProperties || breakdownType === BreakdownType.CustomProperty) {
+            if (customProperty !== undefined) {
+                updates.$set.customProperty = customProperty;
+            }
         } else {
             updates.$unset ??= {};
             updates.$unset.customProperty = 1;
         }
-
-        updates.$set ??= {};
-        updates.$set.analysisSubject = analysisSubject;
     }
 
     if (filters !== undefined) {

--- a/webapp/src/common/models/BreakdownType.ts
+++ b/webapp/src/common/models/BreakdownType.ts
@@ -4,6 +4,7 @@ export enum BreakdownType {
     ProjectDefined = "projectDefined",
     ProjectUsedIn = "projectUsedIn",
     Tag = "tag",
+    CustomProperty = "customProperty",
 }
 
 export function getValidBreakdownTypes(analysisSubject?: AnalysisSubject): BreakdownType[] {
@@ -11,7 +12,7 @@ export function getValidBreakdownTypes(analysisSubject?: AnalysisSubject): Break
         case AnalysisSubject.Components:
             return [BreakdownType.ProjectUsedIn];
         case AnalysisSubject.Projects:
-            return [BreakdownType.ProjectDefined, BreakdownType.Tag];
+            return [BreakdownType.ProjectDefined, BreakdownType.Tag, BreakdownType.CustomProperty];
         case AnalysisSubject.Tags:
             return [BreakdownType.ProjectDefined, BreakdownType.ProjectUsedIn];
         case AnalysisSubject.CustomProperties:
@@ -42,5 +43,7 @@ export function getBreakdownTypeLabel(breakdownType: BreakdownType): string {
             return "Project it's used in";
         case BreakdownType.Tag:
             return "Tag";
+        case BreakdownType.CustomProperty:
+            return "Custom property";
     }
 }

--- a/webapp/src/frontend/containers/analytics/Analytics.tsx
+++ b/webapp/src/frontend/containers/analytics/Analytics.tsx
@@ -51,7 +51,7 @@ interface Props {
     onAnalysisTypeChange(analysisType: AnalysisType): void;
     onAnalysisSubjectChange(analysisSubject: AnalysisSubject, customProperty?: string): void;
     onFiltersChange(filters: Filter[]): void;
-    onBreakdownTypeChange(breakdownType: BreakdownType | undefined): void;
+    onBreakdownTypeChange(breakdownType: BreakdownType | undefined, customProperty?: string): void;
     onTimeSeriesFilterChange(timeSeriesFilter: TimeSeriesFilter): void;
 }
 

--- a/webapp/src/frontend/containers/analytics/filters/Filters.tsx
+++ b/webapp/src/frontend/containers/analytics/filters/Filters.tsx
@@ -23,7 +23,7 @@ interface Props {
     onAnalysisTypeChange(analysisType: AnalysisType): void;
     onAnalysisSubjectChange(analysisSubject: AnalysisSubject, customProperty?: string): void;
     onFiltersChange(filters: Filter[]): void;
-    onBreakdownTypeChange(breakdownType: BreakdownType | undefined): void;
+    onBreakdownTypeChange(breakdownType: BreakdownType | undefined, customProperty?: string): void;
 }
 
 export function Filters({
@@ -68,6 +68,8 @@ export function Filters({
                     <BreakdownWidget
                         analysisSubject={analysisSubject}
                         breakdownType={breakdownType}
+                        customProperty={customProperty}
+                        customProperties={customProperties}
                         onBreakdownChange={onBreakdownTypeChange}
                         disabled={disabled}/>
                 )}

--- a/webapp/src/frontend/containers/analytics/widgets/breakdownWidget/BreakdownWidget.tsx
+++ b/webapp/src/frontend/containers/analytics/widgets/breakdownWidget/BreakdownWidget.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { type AnalysisSubject } from "../../../../../common/models/AnalysisSubject";
-import { type BreakdownType, getBreakdownTypeLabel, getValidBreakdownTypes } from "../../../../../common/models/BreakdownType";
+import { BreakdownType, getBreakdownTypeLabel, getValidBreakdownTypes } from "../../../../../common/models/BreakdownType";
 import { type DropdownOption } from "../../../../library/Dropdown/DropdownOption";
 import { H3 } from "../../../../library/Heading/Heading";
 import { IconRemove } from "../../../../library/icons/IconRemove";
@@ -11,23 +11,41 @@ import { WidgetDropdown } from "../widgetDropdown/WidgetDropdown";
 
 import classes from "./BreakdownWidget.module.css";
 
+// A "break down by custom property" choice needs to carry which property to use,
+// so we encode the property name into the option value (the base breakdown types
+// are used verbatim).
+const CUSTOM_PROPERTY_OPTION_PREFIX = "customProperty:";
+
 interface Props {
     analysisSubject?: AnalysisSubject;
     breakdownType?: BreakdownType;
+    customProperty?: string;
+    customProperties?: Record<string, (string | number | boolean | Date)[]>;
     disabled?: boolean;
-    onBreakdownChange(type: BreakdownType | undefined): void;
+    onBreakdownChange(type: BreakdownType | undefined, customProperty?: string): void;
 }
 
-function getBreakdownOption(breakdownType: BreakdownType): DropdownOption<BreakdownType> {
-    return {
-        value: breakdownType,
-        label: getBreakdownTypeLabel(breakdownType),
-    };
+function getBreakdownOptions(
+    analysisSubject: AnalysisSubject | undefined,
+    customProperties: Record<string, unknown> | undefined,
+): DropdownOption<string>[] {
+    return getValidBreakdownTypes(analysisSubject).flatMap(breakdownType => {
+        if (breakdownType === BreakdownType.CustomProperty) {
+            return Object.keys(customProperties ?? {}).map(name => ({
+                value: `${CUSTOM_PROPERTY_OPTION_PREFIX}${name}`,
+                label: `Property: ${name}`,
+            }));
+        }
+
+        return [{ value: breakdownType, label: getBreakdownTypeLabel(breakdownType) }];
+    });
 }
 
 export function BreakdownWidget({
     analysisSubject,
     breakdownType,
+    customProperty,
+    customProperties,
     disabled = false,
     onBreakdownChange,
 }: Props) {
@@ -41,9 +59,14 @@ export function BreakdownWidget({
         setShouldSelectBreakdown(false);
     }
 
-    function handleBreakdownChange(newBreakdownType: BreakdownType) {
+    function handleBreakdownChange(optionValue: string) {
         setShouldSelectBreakdown(false);
-        onBreakdownChange(newBreakdownType);
+
+        if (optionValue.startsWith(CUSTOM_PROPERTY_OPTION_PREFIX)) {
+            onBreakdownChange(BreakdownType.CustomProperty, optionValue.slice(CUSTOM_PROPERTY_OPTION_PREFIX.length));
+        } else {
+            onBreakdownChange(optionValue as BreakdownType);
+        }
     }
 
     function handleRemoveClick() {
@@ -52,15 +75,17 @@ export function BreakdownWidget({
     }
 
     function renderBreakdownValue() {
-        const breakdownOptions = getValidBreakdownTypes(analysisSubject);
-        const options = breakdownOptions.map(getBreakdownOption);
+        const options = getBreakdownOptions(analysisSubject, customProperties);
+        const value = breakdownType === BreakdownType.CustomProperty && customProperty
+            ? `${CUSTOM_PROPERTY_OPTION_PREFIX}${customProperty}`
+            : breakdownType;
 
         if (breakdownType) {
             return (
                 <WidgetDropdown
                     className={classes.breakdownDropdown}
                     options={options}
-                    value={breakdownType}
+                    value={value}
                     disabled={disabled}
                     onChange={handleBreakdownChange}/>
             );

--- a/webapp/src/frontend/pages/newAnalytics/NewAnalytics.tsx
+++ b/webapp/src/frontend/pages/newAnalytics/NewAnalytics.tsx
@@ -5,7 +5,7 @@ import { generatePath, Link, useNavigate, useParams, useSearchParams } from "rea
 
 import { AnalysisSubject, toAnalysisSubject } from "../../../common/models/AnalysisSubject";
 import { AnalysisType, toAnalysisType } from "../../../common/models/AnalysisType";
-import { toBreakdownType, type BreakdownType } from "../../../common/models/BreakdownType";
+import { toBreakdownType, BreakdownType } from "../../../common/models/BreakdownType";
 import { type Filter } from "../../../common/models/Filter";
 import { type TimeSeriesFilter, DEFAULT_TIME_SERIES_FILTER, toTimeSeriesFilter } from "../../../common/models/TimeSeriesFilter";
 import { RoutePath } from "../../../common/RoutePath";
@@ -100,13 +100,23 @@ export function NewAnalytics() {
         setSearchParams(newSearchParams, { replace: true });
     }
 
-    function handleBreakdownTypeChange(newBreakdownType: BreakdownType | undefined) {
+    function handleBreakdownTypeChange(newBreakdownType: BreakdownType | undefined, breakdownCustomProperty?: string) {
         const newSearchParams = new URLSearchParams(searchParams);
 
         if (newBreakdownType) {
             newSearchParams.set("breakdown", newBreakdownType);
         } else {
             newSearchParams.delete("breakdown");
+        }
+
+        // Breaking down by a custom property reuses the `customProperty` param
+        // (only the custom-property analysis subject uses it otherwise).
+        if (analysisSubject !== AnalysisSubject.CustomProperties) {
+            if (newBreakdownType === BreakdownType.CustomProperty && breakdownCustomProperty) {
+                newSearchParams.set("customProperty", breakdownCustomProperty);
+            } else {
+                newSearchParams.delete("customProperty");
+            }
         }
 
         setSearchParams(newSearchParams, { replace: true });
@@ -171,10 +181,15 @@ export function NewAnalytics() {
         const newAnalysisSubject = toAnalysisSubject(searchParams.get("subject"));
         setAnalysisSubject(newAnalysisSubject);
 
-        const newCustomProperty = searchParams.get("customProperty");
-        setCustomProperty(newCustomProperty === null ? undefined : newCustomProperty);
+        const newCustomProperty = searchParams.get("customProperty") ?? undefined;
+        setCustomProperty(newCustomProperty);
 
-        setBreakdownType(toBreakdownType(searchParams.get("breakdown"), newAnalysisSubject));
+        // A custom-property breakdown is meaningless without a property to group by.
+        let newBreakdownType = toBreakdownType(searchParams.get("breakdown"), newAnalysisSubject);
+        if (newBreakdownType === BreakdownType.CustomProperty && !newCustomProperty) {
+            newBreakdownType = undefined;
+        }
+        setBreakdownType(newBreakdownType);
         setTimeSeriesFilter(toTimeSeriesFilter(searchParams.get("timeSeriesFilter")));
 
         const filtersParam = searchParams.get("filters");

--- a/webapp/src/frontend/pages/savedChart/SavedChart.tsx
+++ b/webapp/src/frontend/pages/savedChart/SavedChart.tsx
@@ -5,7 +5,7 @@ import { Link, generatePath, useNavigate, useParams, useSearchParams } from "rea
 
 import { AnalysisSubject } from "../../../common/models/AnalysisSubject";
 import { AnalysisType } from "../../../common/models/AnalysisType";
-import { type BreakdownType } from "../../../common/models/BreakdownType";
+import { BreakdownType } from "../../../common/models/BreakdownType";
 import { type Filter, hasSameFilters } from "../../../common/models/Filter";
 import {
     type TimeSeriesFilter,
@@ -88,7 +88,8 @@ export function SavedChart() {
     }
 
     function getCustomProperty() {
-        if (getAnalysisSubject() !== AnalysisSubject.CustomProperties) {
+        // The property is used either as the analysis subject or as the breakdown dimension.
+        if (getAnalysisSubject() !== AnalysisSubject.CustomProperties && getBreakdownType() !== BreakdownType.CustomProperty) {
             return undefined;
         }
 
@@ -189,7 +190,7 @@ export function SavedChart() {
         setSearchParams(newSearchParams, { replace: true });
     }
 
-    function handleBreakdownTypeChange(breakdownType: BreakdownType | undefined) {
+    function handleBreakdownTypeChange(breakdownType: BreakdownType | undefined, breakdownCustomProperty?: string) {
         let newOverriddenBreakdownType: BreakdownType | undefined | null = undefined;
         if (breakdownType === savedChart!.breakdownType) {
             newOverriddenBreakdownType = undefined;
@@ -207,6 +208,16 @@ export function SavedChart() {
             newSearchParams.set("breakdown", newOverriddenBreakdownType);
         } else {
             newSearchParams.delete("breakdown");
+        }
+
+        // Breaking down by a custom property reuses the `customProperty` param, which
+        // otherwise belongs to the custom-property analysis subject.
+        if (getAnalysisSubject() !== AnalysisSubject.CustomProperties) {
+            if (breakdownType === BreakdownType.CustomProperty && breakdownCustomProperty) {
+                newSearchParams.set("customProperty", breakdownCustomProperty);
+            } else {
+                newSearchParams.delete("customProperty");
+            }
         }
 
         setSearchParams(newSearchParams, { replace: true });
@@ -296,13 +307,16 @@ export function SavedChart() {
 
     async function handleUpdateConfig() {
         try {
+            const savedTimeSeriesFilter = getAnalysisType() === AnalysisType.DataOverTime ? getTimeSeriesFilter() : undefined;
+
             await updateSavedChart(workspaceSlug!, savedChartSlug, {
-                analysisType: overriddenAnalysisType,
-                analysisSubject: overriddenAnalysisSubject,
+                analysisType: getAnalysisType(),
+                analysisSubject: getAnalysisSubject(),
                 customProperty: getCustomProperty(),
-                filters: overriddenFilters,
-                breakdownType: overriddenBreakdownType,
-                timeSeriesFilter: overriddenTimeSeriesFilter,
+                filters: getFilters(),
+                // Send `null` (not `undefined`) so the backend unsets a previously saved breakdown
+                breakdownType: getBreakdownType() ?? null,
+                timeSeriesFilter: savedTimeSeriesFilter,
             });
 
             const update = {
@@ -442,7 +456,6 @@ export function SavedChart() {
             newOverriddenCustomProperty = customProperty === savedChart.customProperty ? undefined : customProperty;
         }
         setOverriddenAnalysisSubject(newOverriddenAnalysisSubject);
-        setOverriddenCustomProperty(newOverriddenCustomProperty);
 
         const timeSeriesFilter = toTimeSeriesFilter(searchParams.get("timeSeriesFilter"));
         const isSameTimeSeriesFilter = hasSameTimeSeriesFilters(timeSeriesFilter, savedChart?.timeSeriesFilter);
@@ -477,6 +490,17 @@ export function SavedChart() {
             newOverriddenBreakdownType = breakdown as BreakdownType;
         }
         setOverriddenBreakdownType(newOverriddenBreakdownType);
+
+        // When breaking down by a custom property (and not analyzing one), the
+        // `customProperty` param holds the breakdown's property name.
+        const effectiveAnalysisSubject = newOverriddenAnalysisSubject ?? savedChart.analysisSubject;
+        const effectiveBreakdownType = newOverriddenBreakdownType === null
+            ? undefined
+            : newOverriddenBreakdownType ?? savedChart.breakdownType;
+        if (effectiveAnalysisSubject !== AnalysisSubject.CustomProperties && effectiveBreakdownType === BreakdownType.CustomProperty) {
+            newOverriddenCustomProperty = customProperty === savedChart.customProperty ? undefined : customProperty;
+        }
+        setOverriddenCustomProperty(newOverriddenCustomProperty);
 
         const humanReadableSlug = getHumanReadableSlug(savedChart.name, savedChartSlug);
         const pathname = generatePath(RoutePath.SavedChart, { workspaceSlug: workspaceSlug!, savedChartSlug: humanReadableSlug });
@@ -514,6 +538,7 @@ export function SavedChart() {
             (
                 overriddenAnalysisType !== undefined ||
                 overriddenAnalysisSubject !== undefined ||
+                overriddenCustomProperty !== undefined ||
                 overriddenFilters !== undefined ||
                 overriddenBreakdownType !== undefined ||
                 overriddenTimeSeriesFilter !== undefined


### PR DESCRIPTION
Allow analyses (e.g. Projects) to be broken down by a custom property such as "DS Version", as a new breakdown dimension alongside the existing ones.

- New BreakdownType.CustomProperty, valid for the Projects subject.
- dataTransformer: grouping, sorting (with a "(not set)" bucket last) and filter links for the new breakdown type.
- BreakdownWidget lists each custom property as a "Property: X" option, encoding the property name into the option value.
- Thread the breakdown's customProperty through the onBreakdownTypeChange callbacks, reusing the customProperty URL param.
- Persist the property when used as either the subject or the breakdown, and save effective (not just overridden) config values, sending null to unset a removed breakdown.