### PR TITLE
Add Component Props page

### DIFF
--- a/webapp/src/backend/router/api.ts
+++ b/webapp/src/backend/router/api.ts
@@ -30,6 +30,7 @@ import { createAuthRequest } from "../service/auth/auth";
 import { cacheValue, extendTTL, getCachedValue, LockError, withWorkspaceSlugWriteLock } from "../service/cache/cache";
 import { type TimeSeriesFilter } from "../service/component/aggregations";
 import {
+    type ComponentPropUsageResult,
     type ComponentUsagesResult,
     type DataAnalysisFilter,
     type UnusedComponentPropResult,
@@ -41,6 +42,7 @@ import {
     analyseTimeSeriesDataAsCSV,
     findLatestComponentsByDefinitionId,
     getComponentProps,
+    getComponentPropsUsage,
     getComponentUsagesWithParentComponent,
     getCustomProperties,
     getDependenciesFor,
@@ -2492,6 +2494,76 @@ apiRouter.get("/workspaces/:workspaceSlug/unused-component-props",
             }
 
             const result = await getUnusedComponentProps(workspace.id, { limit: limit ? Number.parseInt(limit) : undefined });
+            const projectMap = Object.fromEntries(workspace.projects.map(p => [p.packageName, p]));
+            result.forEach(item => {
+                item.component.packageName = projectMap[item.component.packageName]?.alias ?? item.component.packageName;
+            });
+
+            res.status(httpStatus.OK)
+                .set("ETag", computedEtag)
+                .set("Cache-Control", "private")
+                .json(result);
+        } catch (error) {
+            if (error instanceof WorkspaceNotFound || error instanceof MemberNotFound) {
+                throw new ClientError(httpStatus.NOT_FOUND, ErrorResponseCode.WORKSPACE_NOT_FOUND);
+            }
+
+            throw error;
+        }
+    }
+);
+
+apiRouter.get("/workspaces/:workspaceSlug/component-props",
+    authMiddleware({ credentialsRequired: false }),
+    publicAuthMiddleware(),
+    requestValidator({
+        params: {
+            schema: joi.object({
+                workspaceSlug: joi.string(),
+            }),
+        },
+        query: {
+            schema: joi.object({
+                limit: joi.number().optional(),
+            }),
+        },
+    }),
+    async (
+        req: Request<{ workspaceSlug: string; }, {}, {}, { limit?: string; }>,
+        res: Response<ComponentPropUsageResult[] | ClientError>
+    ) => {
+        try {
+            const {
+                auth,
+                publicAuth,
+                params: {
+                    workspaceSlug,
+                },
+                query: {
+                    limit,
+                },
+            } = req;
+
+            const workspace = await getWorkspaceIfAuthorized(workspaceSlug, UserPermission.READ, { auth, publicAuth });
+
+            const dataRevisionId = await getWorkspaceDataRevisionId(workspace.id);
+            const computedEtag = etag(JSON.stringify({
+                cacheVersion: COMPONENTS_ETAG_CACHE_VERSION,
+                workspaceId: workspace.id,
+                dataRevisionId,
+                url: req.originalUrl,
+            }));
+
+            const clientEtag = req.get("If-None-Match");
+            if (clientEtag === computedEtag) {
+                return res.status(httpStatus.NOT_MODIFIED)
+                    .set("ETag", computedEtag)
+                    .set("Cache-Control", "private")
+                    .set("Content-Type", "application/json")
+                    .send();
+            }
+
+            const result = await getComponentPropsUsage(workspace.id, { limit: limit ? Number.parseInt(limit) : undefined });
             const projectMap = Object.fromEntries(workspace.projects.map(p => [p.packageName, p]));
             result.forEach(item => {
                 item.component.packageName = projectMap[item.component.packageName]?.alias ?? item.component.packageName;

--- a/webapp/src/backend/service/component/component.ts
+++ b/webapp/src/backend/service/component/component.ts
@@ -1415,12 +1415,19 @@ export interface UnusedComponentPropResult {
     component: Pick<Component, "id" | "name" | "definitionId" | "packageName">;
 }
 
-export async function getUnusedComponentProps(workspaceId: string, { limit }: { limit?: number; } = {}): Promise<UnusedComponentPropResult[]> {
-    const latestAnalysisId = await getLatestIndexAnalysisId(workspaceId);
-    if (!latestAnalysisId) {
-        return [];
-    }
-    return HistoricComponentIndexModel.aggregate<UnusedComponentPropResult>([
+export interface ComponentPropUsageResult {
+    propName: string;
+    sumOfUsages: number;
+    numberOfUsages: number;
+    component: Pick<Component, "id" | "name" | "definitionId" | "packageName">;
+}
+
+// Shared aggregation stages that, for every (component, prop) pair in the latest
+// analysis, compute `usedProps` (the prop names actually passed by consumers, with
+// one entry per usage that passes it) and `sumOfUsages` (the component's total
+// number of usages). Callers append their own match/project/sort stages.
+function componentPropsUsagePipeline(workspaceId: string, latestAnalysisId: string): PipelineStage[] {
+    return [
         {
             $match: {
                 workspace: new MongooseTypes.ObjectId(workspaceId),
@@ -1569,6 +1576,25 @@ export async function getUnusedComponentProps(workspaceId: string, { limit }: { 
                 },
             },
         },
+    ];
+}
+
+const componentPropProjection = {
+    id: {
+        $toString: "$component._id",
+    },
+    name: "$component.name",
+    definitionId: "$component.definitionId",
+    packageName: "$component.packageName",
+};
+
+export async function getUnusedComponentProps(workspaceId: string, { limit }: { limit?: number; } = {}): Promise<UnusedComponentPropResult[]> {
+    const latestAnalysisId = await getLatestIndexAnalysisId(workspaceId);
+    if (!latestAnalysisId) {
+        return [];
+    }
+    return HistoricComponentIndexModel.aggregate<UnusedComponentPropResult>([
+        ...componentPropsUsagePipeline(workspaceId, latestAnalysisId),
         {
             $match: {
                 sumOfUsages: {
@@ -1588,14 +1614,54 @@ export async function getUnusedComponentProps(workspaceId: string, { limit }: { 
             $project: {
                 propName: 1,
                 sumOfUsages: 1,
-                component: {
-                    id: {
-                        $toString: "$component._id",
+                component: componentPropProjection,
+            },
+        },
+        {
+            $sort: {
+                sumOfUsages: -1,
+            },
+        },
+        ...(limit === undefined ? [] : [{ $limit: limit }]),
+    ]).exec();
+}
+
+export async function getComponentPropsUsage(workspaceId: string, { limit }: { limit?: number; } = {}): Promise<ComponentPropUsageResult[]> {
+    const latestAnalysisId = await getLatestIndexAnalysisId(workspaceId);
+    if (!latestAnalysisId) {
+        return [];
+    }
+    return HistoricComponentIndexModel.aggregate<ComponentPropUsageResult>([
+        ...componentPropsUsagePipeline(workspaceId, latestAnalysisId),
+        {
+            $addFields: {
+                // How many of the component's usages actually pass this prop.
+                numberOfUsages: {
+                    $size: {
+                        $filter: {
+                            input: "$usedProps",
+                            "as": "usedProp",
+                            cond: {
+                                $eq: ["$$usedProp", "$propName"],
+                            },
+                        },
                     },
-                    name: "$component.name",
-                    definitionId: "$component.definitionId",
-                    packageName: "$component.packageName",
                 },
+            },
+        },
+        {
+            $match: {
+                sumOfUsages: {
+                    $gt: 0,
+                },
+            },
+        },
+        {
+            $project: {
+                propName: 1,
+                sumOfUsages: 1,
+                numberOfUsages: 1,
+                component: componentPropProjection,
             },
         },
         {

--- a/webapp/src/common/RoutePath.ts
+++ b/webapp/src/common/RoutePath.ts
@@ -19,6 +19,7 @@ export enum RoutePath {
     SavedChart = "/:workspaceSlug/analytics/saved-charts/:savedChartSlug",
     Components = "/:workspaceSlug/components",
     ComponentDetail = "/:workspaceSlug/components/:componentSlug",
+    Props = "/:workspaceSlug/props",
     CoreSelection = "/:workspaceSlug/manage-tags/core",
     Onboarding = "/:workspaceSlug/onboarding",
     QuickStart = "/:workspaceSlug/quick-start",

--- a/webapp/src/frontend/App.tsx
+++ b/webapp/src/frontend/App.tsx
@@ -35,6 +35,7 @@ import { InvalidInvite } from "./pages/invalidInvite/InvalidInvite";
 import { NewAnalytics } from "./pages/newAnalytics/NewAnalytics";
 import { Onboarding } from "./pages/onboarding/Onboarding";
 import { PopularCharts } from "./pages/popularCharts/PopularCharts";
+import { Props } from "./pages/props/Props";
 import { DesignerQuickStart } from "./pages/quickStart/designerQuickStart/DesignerQuickStart";
 import { DeveloperQuickStart } from "./pages/quickStart/developerQuickStart/DeveloperQuickStart";
 import { QuickStart } from "./pages/quickStart/QuickStart";
@@ -102,6 +103,7 @@ const router = createBrowserRouter(
                     <Route index element={<Components/>}/>
                     <Route path=":componentSlug/:activeTab?" element={<ComponentDetail/>}/>
                 </Route>
+                <Route path="props" element={<Props/>}/>
                 <Route path="manage-tags" element={
                     <Navigate to="../components"/>
                 }/>

--- a/webapp/src/frontend/api/api.ts
+++ b/webapp/src/frontend/api/api.ts
@@ -18,6 +18,7 @@ import { type APIResponse } from "../models/APIResponse";
 import { type AuthProviders } from "../models/AuthProviders";
 import { type Component } from "../models/Component";
 import { type ComponentProps } from "../models/ComponentProps";
+import { type ComponentPropUsageResult } from "../models/ComponentPropUsageResult";
 import { type ComponentsResponse } from "../models/ComponentsResponse";
 import { type ComponentUsage } from "../models/ComponentUsage";
 import { type DataIssue } from "../models/DataIssue";
@@ -527,6 +528,15 @@ export async function getUnusedComponentProps(workspaceSlug: string, params: { l
     }
     const response = await http.get(url.toString(), { signal });
     return handleResponse<UnusedComponentPropResult[]>(response);
+}
+
+export async function getComponentPropsUsage(workspaceSlug: string, params: { limit?: number; } = {}, signal?: AbortSignal): Promise<ComponentPropUsageResult[]> {
+    const url = new URL(`${base}/workspaces/${workspaceSlug}/component-props`, config.APP_BASE_URL);
+    if ("limit" in params && params.limit !== undefined) {
+        url.searchParams.set("limit", params.limit.toString());
+    }
+    const response = await http.get(url.toString(), { signal });
+    return handleResponse<ComponentPropUsageResult[]>(response);
 }
 
 interface AuthRequestParams {

--- a/webapp/src/frontend/containers/header/tabs/Tabs.tsx
+++ b/webapp/src/frontend/containers/header/tabs/Tabs.tsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
-import { type LinkProps, NavLink } from "react-router-dom";
+import { type LinkProps, NavLink, generatePath, useParams } from "react-router-dom";
 
+import { RoutePath } from "../../../../common/RoutePath";
 import { useStore } from "../../../providers/StoreProvider/StoreProvider";
 
 import classes from "./Tabs.module.css";
@@ -17,12 +18,14 @@ function Tab({ children, to, ...props }: LinkProps) {
 }
 
 export function Tabs() {
+    const { workspaceSlug } = useParams();
     const { selectors: { getAnalyticsURL, getComponentsURL } } = useStore();
 
     return (
         <nav className={classes.tabs}>
             <Tab to={getAnalyticsURL()}>Analytics</Tab>
             <Tab to={getComponentsURL()}>Components</Tab>
+            <Tab to={generatePath(RoutePath.Props, { workspaceSlug: workspaceSlug! })}>Props</Tab>
         </nav>
     );
 }

--- a/webapp/src/frontend/models/ComponentPropUsageResult.ts
+++ b/webapp/src/frontend/models/ComponentPropUsageResult.ts
@@ -1,0 +1,8 @@
+import { type Component } from "./Component";
+
+export interface ComponentPropUsageResult {
+    propName: string;
+    sumOfUsages: number;
+    numberOfUsages: number;
+    component: Pick<Component, "id" | "name" | "definitionId" | "packageName">;
+}

--- a/webapp/src/frontend/pages/componentDetail/propsTable/PropsTable.module.css
+++ b/webapp/src/frontend/pages/componentDetail/propsTable/PropsTable.module.css
@@ -74,6 +74,7 @@
     display: flex;
     align-items: center;
     height: 56px;
+    text-align: start;
     gap: var(--spacing-m);
     font-size: 13px;
     color: var(--label-primary-color);

--- a/webapp/src/frontend/pages/popularCharts/insight/TableInsight.tsx
+++ b/webapp/src/frontend/pages/popularCharts/insight/TableInsight.tsx
@@ -1,15 +1,21 @@
 import { type ReactNode, useMemo } from "react";
 
 import { type Emoji } from "emoji-type";
+import { Link, generatePath, useParams } from "react-router-dom";
 
+import { RoutePath } from "../../../../common/RoutePath";
 import { Callout, CalloutKind } from "../../../library/Callout/Callout";
 import { PredefinedTableType } from "../constants";
 import { type RowData } from "../paginatedTable/PaginatedTable";
 
-function CompleteListInsightContent() {
+function CompleteListInsightContent({ workspaceSlug }: { workspaceSlug: string; }) {
     return (
         <>
-            Looking for a complete list of unused props? We’d love to hear from you.
+            Looking for the complete list of unused props?{" "}
+            <Link to={{ pathname: generatePath(RoutePath.Props, { workspaceSlug }), search: "?usage=unused" }}>
+                View all unused props
+            </Link>
+            .
         </>
     );
 }
@@ -32,12 +38,14 @@ export function TableInsight({
     data,
     showCompleteListInsight,
 }: Props) {
+    const { workspaceSlug } = useParams();
+
     function getUnusedComponentPropsInsight(): InsightContent {
         if (showCompleteListInsight) {
             return {
                 kind: CalloutKind.Onboarding,
                 emoji: "🧐",
-                insight: <CompleteListInsightContent/>,
+                insight: <CompleteListInsightContent workspaceSlug={workspaceSlug!}/>,
             };
         }
 
@@ -69,7 +77,7 @@ export function TableInsight({
         }
     }
 
-    const { kind, emoji, insight } = useMemo(() => getPredefinedTableInsight() ?? { insight: null }, [tableType, data, showCompleteListInsight]);
+    const { kind, emoji, insight } = useMemo(() => getPredefinedTableInsight() ?? { insight: null }, [tableType, data, showCompleteListInsight, workspaceSlug]);
 
     if (!insight) {
         return null;

--- a/webapp/src/frontend/pages/popularCharts/paginatedTable/PaginatedTable.module.css
+++ b/webapp/src/frontend/pages/popularCharts/paginatedTable/PaginatedTable.module.css
@@ -1,5 +1,6 @@
 .paginatedTable {
     --row-height: 50px;
+    --page-size: 5;
 }
 
 .paginatedTable .header,
@@ -18,7 +19,7 @@
 }
 
 .paginatedTable .body {
-    height: calc(var(--row-height) * 5);
+    height: calc(var(--row-height) * var(--page-size));
 }
 
 .paginatedTable .row {

--- a/webapp/src/frontend/pages/popularCharts/paginatedTable/PaginatedTable.tsx
+++ b/webapp/src/frontend/pages/popularCharts/paginatedTable/PaginatedTable.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode, useMemo } from "react";
+import { useState, type CSSProperties, type ReactNode, useMemo } from "react";
 
 import classNames from "classnames";
 import { Link } from "react-router-dom";
@@ -57,13 +57,14 @@ function TableRow({
 interface Props {
     rowClassName?: string;
     columnClassNames: string[];
-    headers: string[];
+    headers: ReactNode[];
     rows: RowData[];
     linksDisabled: boolean;
+    pageSize?: number;
     onPageChange?(page: number, pageSize: number): void;
 }
 
-const CHUNK_SIZE = 5;
+const DEFAULT_PAGE_SIZE = 5;
 
 export function PaginatedTable({
     rowClassName,
@@ -71,11 +72,12 @@ export function PaginatedTable({
     headers,
     rows,
     linksDisabled,
+    pageSize = DEFAULT_PAGE_SIZE,
     onPageChange,
 }: Props) {
     const [currentPage, setCurrentPage] = useState(0);
 
-    const pages = useMemo(() => [...arrayChunk(rows, CHUNK_SIZE)], [rows]);
+    const pages = useMemo(() => [...arrayChunk(rows, pageSize)], [rows, pageSize]);
 
     function handleBackClick() {
         onPageChange?.(currentPage, pages.length);
@@ -88,7 +90,7 @@ export function PaginatedTable({
     }
 
     return (
-        <div className={classes.paginatedTable}>
+        <div className={classes.paginatedTable} style={{ "--page-size": pageSize } as CSSProperties}>
             <div className={classes.header}>
                 {headers.map((header, index) =>
                     <div key={index} className={columnClassNames[index]}>{header}</div>
@@ -97,7 +99,7 @@ export function PaginatedTable({
             <div className={classes.body}>
                 {pages[currentPage].map((row, index) =>
                     <TableRow
-                        key={currentPage * CHUNK_SIZE + index}
+                        key={currentPage * pageSize + index}
                         rowClassName={rowClassName}
                         columnClassNames={columnClassNames}
                         linksDisabled={linksDisabled}

--- a/webapp/src/frontend/pages/props/Props.module.css
+++ b/webapp/src/frontend/pages/props/Props.module.css
@@ -1,0 +1,100 @@
+.props {
+    display: flex;
+    height: calc(100vh - var(--header-height));
+}
+
+.props .content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-s);
+    padding: 40px var(--spacing-xxl) 136px;
+    overflow: auto;
+}
+
+.props .titleBlock {
+    margin-bottom: var(--spacing-s);
+}
+
+.props .title {
+    margin-bottom: 4px;
+}
+
+.props .description {
+    font-size: 13px;
+    line-height: 18px;
+    color: var(--label-secondary-color);
+}
+
+.props .activeFilters {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--spacing-xs);
+}
+
+.props .search {
+    width: 224px;
+}
+
+.props .filter {
+    min-width: 160px;
+}
+
+.props .availableFilters {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--spacing-xs);
+    margin-bottom: var(--spacing-s);
+}
+
+.props .filterBy {
+    flex-shrink: 0;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 16px;
+    color: var(--label-secondary-color);
+}
+
+.props .sortHeader {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+}
+
+.props .sortHeader:hover {
+    color: var(--label-primary-color);
+}
+
+.props .propColumn {
+    flex: 1;
+    font-family: var(--font-family-secondary);
+}
+
+.props .row:not(.linksDisabled):hover .propColumn {
+    text-decoration: underline;
+}
+
+.props .componentColumn {
+    flex: 1;
+    overflow: hidden;
+}
+
+.props .projectColumn {
+    flex: 1;
+    overflow: hidden;
+    color: var(--label-secondary-color);
+}
+
+.props .usedColumn {
+    width: 80px;
+    text-align: right;
+    color: var(--label-secondary-color);
+}

--- a/webapp/src/frontend/pages/props/Props.tsx
+++ b/webapp/src/frontend/pages/props/Props.tsx
@@ -1,0 +1,412 @@
+import { useEffect, useMemo, useState } from "react";
+
+import classNames from "classnames";
+import { generatePath, useSearchParams } from "react-router-dom";
+
+import {
+    type NumberFilterOperation,
+    type StringFilterOperation,
+    FilterOperation,
+} from "../../../common/models/FilterOperation";
+import { RoutePath } from "../../../common/RoutePath";
+import { getComponentPropsUsage } from "../../api/api";
+import { Dropdown } from "../../library/Dropdown/Dropdown";
+import { type DropdownOption } from "../../library/Dropdown/DropdownOption";
+import { FilterPill } from "../../library/FilterPill/FilterPill";
+import { H1 } from "../../library/Heading/Heading";
+import { IconChevronDown } from "../../library/icons/IconChevronDown";
+import { IconChevronUp } from "../../library/icons/IconChevronUp";
+import { PopoverDirection } from "../../library/Popover/Popover";
+import { SearchInput } from "../../library/SearchInput/SearchInput";
+import { logError } from "../../logger";
+import { AccessLevel } from "../../models/AccessLevel";
+import { type ComponentPropUsageResult } from "../../models/ComponentPropUsageResult";
+import { SortOrder } from "../../models/SortOrder";
+import { useStore } from "../../providers/StoreProvider/StoreProvider";
+import { isValidRegex } from "../../utils";
+import { DropdownNumber } from "../components/dropdownNumber/DropdownNumber";
+import { DropdownString } from "../components/dropdownString/DropdownString";
+import { type RowData, PaginatedTable } from "../popularCharts/paginatedTable/PaginatedTable";
+
+import classes from "./Props.module.css";
+
+const PAGE_SIZE = 15;
+const ALL_PROJECTS = "__all_projects__";
+
+// Column order must match the `columnClassNames` passed to the table.
+enum SortColumn {
+    Prop = "prop",
+    Component = "component",
+    Project = "project",
+    Used = "used",
+}
+
+const sortColumns = [SortColumn.Prop, SortColumn.Component, SortColumn.Project, SortColumn.Used];
+
+const columnLabels: Record<SortColumn, string> = {
+    [SortColumn.Prop]: "Prop",
+    [SortColumn.Component]: "Component",
+    [SortColumn.Project]: "Project",
+    [SortColumn.Used]: "Used",
+};
+
+function compareProps(a: ComponentPropUsageResult, b: ComponentPropUsageResult, column: SortColumn): number {
+    switch (column) {
+        case SortColumn.Prop:
+            return a.propName.localeCompare(b.propName);
+        case SortColumn.Component:
+            return a.component.name.localeCompare(b.component.name);
+        case SortColumn.Project:
+            return a.component.packageName.localeCompare(b.component.packageName);
+        case SortColumn.Used:
+            return (a.numberOfUsages - b.numberOfUsages) || (a.sumOfUsages - b.sumOfUsages);
+    }
+}
+
+function SortHeader({ label, active, order, onClick }: { label: string; active: boolean; order: SortOrder; onClick(): void; }) {
+    return (
+        <button type="button" className={classes.sortHeader} onClick={onClick}>
+            {label}
+            {active && (
+                order === SortOrder.Descending
+                    ? <IconChevronDown color="var(--label-secondary-color)"/>
+                    : <IconChevronUp color="var(--label-secondary-color)"/>
+            )}
+        </button>
+    );
+}
+
+enum Usage {
+    All = "all",
+    Unused = "unused",
+    Used = "used",
+}
+
+const usageOptions: DropdownOption<Usage>[] = [
+    { value: Usage.All, label: "All props" },
+    { value: Usage.Unused, label: "Unused only" },
+    { value: Usage.Used, label: "Used only" },
+];
+
+// Filters that follow the Components-page "Filter by" add/remove model.
+enum PropFilter {
+    PropName = "propName",
+    Component = "component",
+    ComponentUsages = "componentUsages",
+}
+
+const propFilterLabels: Record<PropFilter, string> = {
+    [PropFilter.PropName]: "Prop name",
+    [PropFilter.Component]: "Component",
+    [PropFilter.ComponentUsages]: "Component usages",
+};
+
+interface StringFilter {
+    operation: StringFilterOperation;
+    value: string;
+}
+
+interface NumberFilter {
+    operation: NumberFilterOperation;
+    value: number | undefined;
+}
+
+const EMPTY_STRING_FILTER: StringFilter = { operation: FilterOperation.Contains, value: "" };
+const EMPTY_NUMBER_FILTER: NumberFilter = { operation: FilterOperation.GreaterThan, value: undefined };
+
+function matchesString(value: string, { operation, value: query }: StringFilter): boolean {
+    const haystack = value.toLowerCase();
+    const needle = query.toLowerCase();
+
+    switch (operation) {
+        case FilterOperation.Contains:
+            return haystack.includes(needle);
+        case FilterOperation.DoesNotContain:
+            return !haystack.includes(needle);
+        case FilterOperation.StartsWith:
+            return haystack.startsWith(needle);
+        case FilterOperation.DoesNotStartWith:
+            return !haystack.startsWith(needle);
+        case FilterOperation.EndsWith:
+            return haystack.endsWith(needle);
+        case FilterOperation.DoesNotEndWith:
+            return !haystack.endsWith(needle);
+        case FilterOperation.Regex:
+            // Don't filter anything out while the regex is still invalid.
+            return !isValidRegex(query) || new RegExp(query, "i").test(value);
+    }
+}
+
+function matchesNumber(value: number, { operation, value: target }: NumberFilter): boolean {
+    switch (operation) {
+        case FilterOperation.GreaterThan:
+            return value > target!;
+        case FilterOperation.LessThan:
+            return value < target!;
+        case FilterOperation.Equals:
+            return value === target;
+    }
+}
+
+function transformProps(workspaceSlug: string, props: ComponentPropUsageResult[]): RowData[] {
+    return props.map(({ propName, numberOfUsages, sumOfUsages, component: { definitionId, packageName, name } }) => {
+        const url = generatePath(RoutePath.ComponentDetail, {
+            workspaceSlug,
+            componentSlug: encodeURIComponent(`${name}::${definitionId}`),
+        });
+        return {
+            link: `${url}#props`,
+            cells: [
+                propName,
+                name,
+                packageName,
+                `${numberOfUsages} of ${sumOfUsages}`,
+            ],
+        };
+    });
+}
+
+export function Props() {
+    const { selectors: { getWorkspace, getAccessLevel } } = useStore();
+    const workspace = getWorkspace();
+    const accessLevel = getAccessLevel();
+    const linksDisabled = accessLevel === AccessLevel.Page;
+
+    const [searchParams] = useSearchParams();
+
+    const [props, setProps] = useState<ComponentPropUsageResult[] | null>(null);
+    const [searchTerm, setSearchTerm] = useState("");
+    const [usage, setUsage] = useState(() => {
+        const param = searchParams.get("usage");
+        if (param === Usage.Unused) {
+            return Usage.Unused;
+        }
+        if (param === Usage.Used) {
+            return Usage.Used;
+        }
+        return Usage.All;
+    });
+    const [selectedProject, setSelectedProject] = useState(ALL_PROJECTS);
+    const [propNameFilter, setPropNameFilter] = useState<StringFilter>(EMPTY_STRING_FILTER);
+    const [componentNameFilter, setComponentNameFilter] = useState<StringFilter>(EMPTY_STRING_FILTER);
+    const [componentUsagesFilter, setComponentUsagesFilter] = useState<NumberFilter>(EMPTY_NUMBER_FILTER);
+    const [addedFilter, setAddedFilter] = useState<PropFilter | null>(null);
+    const [sortColumn, setSortColumn] = useState(SortColumn.Used);
+    const [sortOrder, setSortOrder] = useState(SortOrder.Descending);
+
+    function handleSort(column: SortColumn) {
+        if (column === sortColumn) {
+            setSortOrder(order => order === SortOrder.Descending ? SortOrder.Ascending : SortOrder.Descending);
+        } else {
+            setSortColumn(column);
+            // Text columns read most naturally ascending; the usage count descending.
+            setSortOrder(column === SortColumn.Used ? SortOrder.Descending : SortOrder.Ascending);
+        }
+    }
+
+    useEffect(() => {
+        if (!workspace) {
+            return;
+        }
+
+        const abortController = new AbortController();
+
+        async function fetchData() {
+            try {
+                const result = await getComponentPropsUsage(workspace!.slug, {}, abortController.signal);
+                setProps(result);
+                setSearchTerm("");
+                setSelectedProject(ALL_PROJECTS);
+                setPropNameFilter(EMPTY_STRING_FILTER);
+                setComponentNameFilter(EMPTY_STRING_FILTER);
+                setComponentUsagesFilter(EMPTY_NUMBER_FILTER);
+                setAddedFilter(null);
+            } catch (error) {
+                if (!(error instanceof DOMException) || error.name !== "AbortError") {
+                    logError(error);
+                }
+            }
+        }
+
+        fetchData();
+
+        return () => abortController.abort();
+    }, [workspace]);
+
+    const projectOptions = useMemo<DropdownOption<string>[]>(() => {
+        const projects = [...new Set((props ?? []).map(({ component }) => component.packageName))].sort();
+        return [
+            { value: ALL_PROJECTS, label: "All projects" },
+            ...projects.map(project => ({ value: project, label: project })),
+        ];
+    }, [props]);
+
+    const rows = useMemo(() => {
+        if (props === null) {
+            return null;
+        }
+
+        const search = searchTerm.trim().toLowerCase();
+
+        const filtered = props.filter(({ propName, numberOfUsages, sumOfUsages, component }) => {
+            if (search && !propName.toLowerCase().includes(search) && !component.name.toLowerCase().includes(search)) {
+                return false;
+            }
+            if (usage === Usage.Unused && numberOfUsages !== 0) {
+                return false;
+            }
+            if (usage === Usage.Used && numberOfUsages === 0) {
+                return false;
+            }
+            if (selectedProject !== ALL_PROJECTS && component.packageName !== selectedProject) {
+                return false;
+            }
+            if (propNameFilter.value && !matchesString(propName, propNameFilter)) {
+                return false;
+            }
+            if (componentNameFilter.value && !matchesString(component.name, componentNameFilter)) {
+                return false;
+            }
+            if (componentUsagesFilter.value !== undefined && !matchesNumber(sumOfUsages, componentUsagesFilter)) {
+                return false;
+            }
+            return true;
+        });
+
+        const direction = sortOrder === SortOrder.Ascending ? 1 : -1;
+        const sorted = [...filtered].sort((a, b) => direction * compareProps(a, b, sortColumn));
+
+        return transformProps(workspace!.slug, sorted);
+    }, [props, searchTerm, usage, selectedProject, propNameFilter, componentNameFilter, componentUsagesFilter, sortColumn, sortOrder, workspace]);
+
+    // Remount the table on any filter or sort change so its internal pagination resets to the first page.
+    const filterKey = [
+        searchTerm,
+        usage,
+        selectedProject,
+        `${propNameFilter.operation}:${propNameFilter.value}`,
+        `${componentNameFilter.operation}:${componentNameFilter.value}`,
+        `${componentUsagesFilter.operation}:${componentUsagesFilter.value}`,
+        `${sortColumn}:${sortOrder}`,
+    ].join("|");
+
+    const sortableHeaders = sortColumns.map(column => (
+        <SortHeader
+            key={column}
+            label={columnLabels[column]}
+            active={sortColumn === column}
+            order={sortOrder}
+            onClick={() => handleSort(column)}/>
+    ));
+
+    function isFilterActive(filter: PropFilter): boolean {
+        if (addedFilter === filter) {
+            return true;
+        }
+        switch (filter) {
+            case PropFilter.PropName:
+                return propNameFilter.value !== "";
+            case PropFilter.Component:
+                return componentNameFilter.value !== "";
+            case PropFilter.ComponentUsages:
+                return componentUsagesFilter.value !== undefined;
+        }
+    }
+
+    function renderActiveFilter(filter: PropFilter) {
+        switch (filter) {
+            case PropFilter.PropName:
+                return (
+                    <DropdownString
+                        key={filter}
+                        label={propFilterLabels[filter]}
+                        placeholder="Type a prop name"
+                        operation={propNameFilter.operation}
+                        value={propNameFilter.value}
+                        open={addedFilter === filter}
+                        onChange={(operation, value) => setPropNameFilter({ operation, value })}
+                        onClose={() => setAddedFilter(null)}/>
+                );
+            case PropFilter.Component:
+                return (
+                    <DropdownString
+                        key={filter}
+                        label={propFilterLabels[filter]}
+                        placeholder="Type a component name"
+                        operation={componentNameFilter.operation}
+                        value={componentNameFilter.value}
+                        open={addedFilter === filter}
+                        onChange={(operation, value) => setComponentNameFilter({ operation, value })}
+                        onClose={() => setAddedFilter(null)}/>
+                );
+            case PropFilter.ComponentUsages:
+                return (
+                    <DropdownNumber
+                        key={filter}
+                        label={propFilterLabels[filter]}
+                        operation={componentUsagesFilter.operation}
+                        value={componentUsagesFilter.value}
+                        open={addedFilter === filter}
+                        onChange={(operation, value) => setComponentUsagesFilter({ operation, value })}
+                        onClose={() => setAddedFilter(null)}/>
+                );
+        }
+    }
+
+    const activeFilters = Object.values(PropFilter).filter(isFilterActive);
+    const availableFilters = Object.values(PropFilter).filter(filter => !isFilterActive(filter));
+
+    return (
+        <main className={classes.props}>
+            <div className={classes.content}>
+                <header className={classes.titleBlock}>
+                    <H1 className={classes.title}>Component Props{rows !== null && ` (${rows.length})`}</H1>
+                    <p className={classes.description}>List of all component props and how often each is used across the codebase</p>
+                </header>
+                <div className={classes.activeFilters}>
+                    <SearchInput
+                        className={classes.search}
+                        placeholder="Search props"
+                        value={searchTerm}
+                        onSearch={setSearchTerm}/>
+                    <Dropdown
+                        className={classes.filter}
+                        options={usageOptions}
+                        value={usage}
+                        optionsDirection={PopoverDirection.BottomLeft}
+                        showValueInButton
+                        onChange={setUsage}/>
+                    <Dropdown
+                        className={classes.filter}
+                        placeholder="All projects"
+                        options={projectOptions}
+                        value={selectedProject}
+                        optionsDirection={PopoverDirection.BottomLeft}
+                        showValueInButton
+                        onChange={setSelectedProject}/>
+                    {activeFilters.map(renderActiveFilter)}
+                </div>
+                {availableFilters.length > 0 && (
+                    <div className={classes.availableFilters}>
+                        <span className={classes.filterBy}>Filter by</span>
+                        {availableFilters.map(filter => (
+                            <FilterPill key={filter} onClick={() => setAddedFilter(filter)}>
+                                {propFilterLabels[filter]}
+                            </FilterPill>
+                        ))}
+                    </div>
+                )}
+                {rows !== null && (
+                    <PaginatedTable
+                        key={filterKey}
+                        rowClassName={classNames(classes.row, { [classes.linksDisabled]: linksDisabled })}
+                        columnClassNames={[classes.propColumn, classes.componentColumn, classes.projectColumn, classes.usedColumn]}
+                        headers={sortableHeaders}
+                        rows={rows}
+                        pageSize={PAGE_SIZE}
+                        linksDisabled={linksDisabled}/>
+                )}
+            </div>
+        </main>
+    );
+}


### PR DESCRIPTION
Add a new top-level "Props" page listing every component prop and how often each is used across the codebase, with search, usage/project filters, add/remove filters, and sortable columns.

- Backend: new GET /workspaces/:workspaceSlug/component-props endpoint and getComponentPropsUsage() service, refactoring the unused-props aggregation into a shared pipeline and computing numberOfUsages alongside sumOfUsages.
- Frontend: new Props page, route, header tab, API client and model.
- Generalize PaginatedTable with a configurable pageSize and ReactNode headers (for clickable sort headers).
- Link the popular-charts "complete list of unused props" callout to the new page instead of the dead placeholder text.