### PR TITLE
Refactor auth providers

### DIFF
--- a/webapp/src/backend/router/pages.ts
+++ b/webapp/src/backend/router/pages.ts
@@ -9,12 +9,12 @@ import {
     type AuthRequest,
     authenticateTestUser,
     authProviders,
-    AuthRequestNotFound,
-    createUserSession,
     findAndDeleteAuthRequest,
     getVerifiedAuthPayload,
 } from "../service/auth/auth";
+import { AuthRequestNotFound } from "../service/auth/errors";
 import { LoginProviderType } from "../service/auth/models";
+import { createUserSession } from "../service/auth/utils";
 import { sendEmailChangeNotificationEmail, sendWelcomeEmail } from "../service/emailing";
 import { healthCheckService } from "../service/healthcheck";
 import { logException } from "../service/logger";

--- a/webapp/src/backend/service/auth/auth.ts
+++ b/webapp/src/backend/service/auth/auth.ts
@@ -1,68 +1,29 @@
-import { createOAuthUserAuth as createGithubUserAuth } from "@octokit/auth-oauth-user";
-import { Octokit as GithubAuthClient } from "@octokit/core";
-import { OAuth2Client as GoogleAuthClient } from "google-auth-library";
-import * as jwt from "jsonwebtoken";
+import {
+    type Algorithm as JwtAlgorithm,
+    type JwtPayload,
+    decode as jwtDecode,
+    sign as jwtSign,
+    verify as jwtVerify,
+} from "jsonwebtoken";
 
 import { config } from "../../../config/backend";
-import { type ErrorExtraInfo, ServiceError } from "../error";
-import {
-    type User,
-    createUser,
-    createUserSession as createSession,
-    findUserByEmail,
-    findUserByLoginProvider,
-    isAdminUser,
-    linkExternalAccount,
-    findTestUser,
-} from "../user/user";
+import { type User, findTestUser } from "../user/user";
 import { generateNanoId } from "../utils";
+
+import { AuthRequestNotFound } from "./errors";
+import { authGithubUser, getGithubAuthUrl } from "./github";
+import { authGitlabUser, getGitlabAuthUrl } from "./gitlab";
+import { authGoogleUser, getGoogleAuthUrl } from "./google";
 import {
-    addMember,
-    findWorkspaceInvitesByEmail,
-    markInviteAsUsed,
-    removeMember,
-} from "../workspace/workspace";
-
-import { authGitlabUser, getGitlabAuthUrl } from "./authGitlab";
-import { type AuthRequestDoc, AuthRequestModel, LoginProviderType } from "./models";
-
-export class OAuthFailure extends ServiceError {
-    constructor(provider: LoginProviderType, extra?: ErrorExtraInfo) {
-        super("Authentication failed", {
-            shouldCapture: false,
-            details: {
-                provider,
-                ...extra?.details,
-            },
-            reason: extra?.reason,
-        });
-    }
-}
-
-export class UserNotInvited extends ServiceError {
-    constructor(provider: LoginProviderType, userData: UserData) {
-        super("User not invited", {
-            details: {
-                provider,
-                userData,
-            },
-        });
-    }
-}
-
-export class AuthRequestNotFound extends ServiceError {
-    constructor(code: string) {
-        super(
-            "Auth request not found",
-            {
-                shouldCapture: false,
-                details: {
-                    code,
-                },
-            }
-        );
-    }
-}
+    type AuthRequestDoc,
+    type AuthResult,
+    type AuthToken,
+    type LoginOptions,
+    type TokenPayload,
+    AuthRequestModel,
+    LoginProviderType,
+} from "./models";
+import { authenticateUser, createUserSession } from "./utils";
 
 export class AuthRequest {
     constructor(
@@ -77,135 +38,23 @@ export class AuthRequest {
     }
 }
 
-interface TokenPayload extends jwt.JwtPayload {
-    userId: string;
-    email: string;
-    loginProvider: LoginProviderType;
-    isAdmin?: boolean;
+export interface AuthData extends TokenPayload {
+    sessionId: string;
+    isAdmin: boolean;
 }
 
-type AuthToken = string;
-
-export function generateUserToken(tokenId: string, payload: TokenPayload, isCliSession: boolean): AuthToken {
-    const signOptions: jwt.SignOptions = {
-        jwtid: tokenId,
-        expiresIn: isCliSession ? config.JWT_EXPIRY_CLI : config.JWT_EXPIRY,
-        algorithm: config.JWT_ALGO as jwt.Algorithm,
-        issuer: config.JWT_ISSUER,
-    };
-    const token = jwt.sign(payload, config.JWT_PRIVATE_KEY, signOptions);
-
-    return token;
-}
-
-export async function createUserSession(user: User, loginProvider: LoginProviderType, { isCliSession }: { isCliSession: boolean; }): Promise<AuthToken> {
-    const [session, isAdmin] = await Promise.all([
-        createSession(user.id, loginProvider),
-        isAdminUser(user.id),
-    ]);
-    const payload = {
-        userId: user.id,
-        email: user.email,
-        isAdmin,
-        loginProvider,
-    };
-
-    return generateUserToken(session.id, payload, isCliSession);
-}
-
-interface PublicTokenPayload extends jwt.JwtPayload {
+export interface PublicAuthData extends JwtPayload {
     url: string;
     workspace: string;
 }
 
-export { type PublicTokenPayload as PublicAuthData };
-
-export function generatePublicAuthToken(tokenId: string, payload: PublicTokenPayload): AuthToken {
-    return jwt.sign(payload, config.JWT_PRIVATE_KEY, {
+export function generatePublicAuthToken(tokenId: string, payload: PublicAuthData): AuthToken {
+    return jwtSign(payload, config.JWT_PRIVATE_KEY, {
         jwtid: tokenId,
         noTimestamp: true,
-        algorithm: config.JWT_ALGO as jwt.Algorithm,
+        algorithm: config.JWT_ALGO as JwtAlgorithm,
         issuer: config.JWT_ISSUER,
     });
-}
-
-export interface UserData {
-    email: string;
-    emails?: string[];
-    fullName?: string;
-    avatarUrl?: string;
-    loginProvider: LoginProviderType;
-    externalId: string;
-}
-
-async function registerUser(userData: UserData): Promise<User> {
-    const user = await createUser({
-        email: userData.email,
-        fullName: userData.fullName,
-        avatarUrl: userData.avatarUrl,
-        loginProvider: userData.loginProvider,
-        externalId: userData.externalId,
-    });
-
-    return user;
-}
-
-async function acceptUserInvites(user: User) {
-    const loginProvider = user.loginProviders[0].type;
-    const userData = {
-        email: user.email,
-        fullName: user.fullName,
-        avatarUrl: user.avatarUrl,
-        loginProvider,
-        externalId: user.loginProviders[0].externalId,
-    };
-
-    const invites = await findWorkspaceInvitesByEmail(user.email);
-    if (!invites) {
-        throw new UserNotInvited(loginProvider, userData);
-    }
-
-    for (const invite of invites) {
-        if (invite.expiresAt.getTime() < Date.now() || invite.isUsed) {
-            continue;
-        }
-
-        try {
-            await addMember(invite.workspaceId, user.id);
-            await markInviteAsUsed(invite.code, user.id);
-        } catch (error) {
-            await removeMember(invite.workspaceId, user.id);
-
-            continue;
-        }
-    }
-}
-
-export async function authenticateUser(userData: UserData, { isCliSession }: { isCliSession: boolean; }): Promise<AuthResult> {
-    let user = await findUserByLoginProvider(userData.loginProvider, userData.externalId);
-    let isNewUser = false;
-
-    if (!user) {
-        user = await findUserByEmail(userData.emails ?? userData.email);
-
-        if (user) {
-            await linkExternalAccount(user.id, userData.loginProvider, userData.externalId);
-        } else {
-            user = await registerUser(userData);
-
-            isNewUser = true;
-        }
-    }
-
-    try {
-        await acceptUserInvites(user);
-    } catch (error) {
-        // Silently ignore unhandled invites
-    }
-
-    const token = await createUserSession(user, userData.loginProvider, { isCliSession });
-
-    return { user, token, isNewUser };
 }
 
 export async function authenticateTestUser({ isCliSession }: { isCliSession: boolean; }): Promise<AuthResult> {
@@ -215,151 +64,6 @@ export async function authenticateTestUser({ isCliSession }: { isCliSession: boo
 
     return { user, token, isNewUser: false };
 }
-
-const GOOGLE_REDIRECT_URI = `${config.APP_BASE_URL}${config.GOOGLE_LOGIN_PATH}`;
-
-function getGoogleClient(): GoogleAuthClient {
-    return new GoogleAuthClient(
-        config.GOOGLE_CLIENT_ID,
-        config.GOOGLE_CLIENT_SECRET,
-        GOOGLE_REDIRECT_URI
-    );
-}
-
-function getGoogleAuthUrl(state: string): string {
-    const oAuth2Client = getGoogleClient();
-
-    return oAuth2Client.generateAuthUrl({
-        prompt: "select_account",
-        access_type: "offline",
-        scope: [
-            "https://www.googleapis.com/auth/userinfo.profile",
-            "https://www.googleapis.com/auth/userinfo.email",
-        ],
-        state,
-    });
-}
-
-interface GoogleIdPayload {
-    iss: string;
-    aud: string;
-    sub: string;
-    email: string;
-    email_verified: boolean;
-    name?: string;
-    picture?: string;
-    given_name?: string;
-    family_name?: string;
-    iat: number;
-    exp: number;
-}
-
-function decodeGoogleIdToken(idToken: string): GoogleIdPayload {
-    return jwt.decode(idToken) as GoogleIdPayload;
-}
-
-export interface LoginOptions {
-    isCliSession: boolean;
-}
-
-export interface AuthResult {
-    user: User;
-    token: AuthToken;
-    isNewUser: boolean;
-}
-
-async function authGoogleUser(authCode: string, { isCliSession = false }: LoginOptions): Promise<AuthResult> {
-    try {
-        const oAuth2Client = getGoogleClient();
-        const response = await oAuth2Client.getToken(authCode);
-        const idToken = response.tokens.id_token;
-
-        if (!idToken) {
-            throw new OAuthFailure(LoginProviderType.Google);
-        }
-
-        const idPayload = decodeGoogleIdToken(idToken);
-        const userData: UserData = {
-            loginProvider: LoginProviderType.Google,
-            email: idPayload.email,
-            externalId: idPayload.sub,
-            fullName: [idPayload.given_name ?? "", idPayload.family_name ?? ""].join(" "),
-            avatarUrl: idPayload.picture,
-        };
-
-        return authenticateUser(userData, { isCliSession });
-    } catch (err) {
-        throw new OAuthFailure(LoginProviderType.Google, {
-            reason: err as Error,
-        });
-    }
-}
-
-const GITHUB_REDIRECT_URI = `${config.APP_BASE_URL}${config.GITHUB_LOGIN_PATH}`;
-
-function getGithubAuthUrl(state: string, { error }: { error?: string; }): string {
-    if (error) {
-        const errorUrl = new URL(`${config.APP_BASE_URL}/login`);
-        errorUrl.searchParams.append("error", `github_${error}`);
-        return errorUrl.toString();
-    }
-    const url = new URL("https://github.com/login/oauth/authorize");
-
-    url.searchParams.append("client_id", config.GITHUB_CLIENT_ID);
-    url.searchParams.append("scope", "read:user user:email");
-    url.searchParams.append("redirect_uri", GITHUB_REDIRECT_URI);
-
-    if (state) {
-        url.searchParams.append("state", state);
-    }
-
-    return url.toString();
-}
-
-async function authGithubUser(authCode: string, { isCliSession = false }: LoginOptions): Promise<AuthResult> {
-    try {
-        const githubUserAuth = createGithubUserAuth({
-            clientId: config.GITHUB_CLIENT_ID,
-            clientSecret: config.GITHUB_CLIENT_SECRET,
-            code: authCode,
-            redirectUrl: GITHUB_REDIRECT_URI,
-        });
-
-        const { token: auth } = await githubUserAuth();
-        const octokit = new GithubAuthClient({ auth });
-
-        const [{ data: userProfile }, { data: userEmails }] = await Promise.all([
-            octokit.request("GET /user"),
-            octokit.request("GET /user/emails"),
-        ]);
-
-        const verifiedEmails = userEmails.filter(e => e.verified).map(e => ({ email: e.email, primary: e.primary }));
-        const emails = verifiedEmails.map(e => e.email);
-        const primaryEmail = verifiedEmails.find(({ primary }) => primary)?.email ?? emails[0];
-
-        const userData: UserData = {
-            loginProvider: LoginProviderType.Github,
-            email: primaryEmail,
-            emails,
-            externalId: userProfile.id.toString(),
-        };
-
-        if (userProfile.name) {
-            userData.fullName = userProfile.name;
-        }
-
-        if (userProfile.avatar_url) {
-            userData.avatarUrl = userProfile.avatar_url;
-        }
-
-        return authenticateUser(userData, { isCliSession });
-    } catch (err) {
-        throw new OAuthFailure(LoginProviderType.Github, {
-            reason: err as Error,
-        });
-    }
-}
-
 
 // This function is not called.
 // Email auth uses POST /api/auth-request instead
@@ -409,15 +113,10 @@ export const authProviders: Record<LoginProviderType, Provider> = {
     },
 };
 
-export interface AuthData extends TokenPayload {
-    sessionId: string;
-    isAdmin: boolean;
-}
-
 export function getVerifiedAuthPayload(token: string): AuthData | undefined {
     try {
-        const tokenPayload = jwt.verify(token, config.JWT_PUBLIC_KEY, {
-            algorithms: [config.JWT_ALGO as jwt.Algorithm],
+        const tokenPayload = jwtVerify(token, config.JWT_PUBLIC_KEY, {
+            algorithms: [config.JWT_ALGO as JwtAlgorithm],
         }) as TokenPayload;
 
         return {
@@ -434,7 +133,7 @@ export function getVerifiedAuthPayload(token: string): AuthData | undefined {
 
 export function decodeAuthData(token: string): AuthData | undefined {
     try {
-        const tokenPayload = jwt.decode(token) as TokenPayload;
+        const tokenPayload = jwtDecode(token) as TokenPayload;
 
         return {
             sessionId: tokenPayload.jti as string,

--- a/webapp/src/backend/service/auth/errors.ts
+++ b/webapp/src/backend/service/auth/errors.ts
@@ -1,0 +1,41 @@
+import { type ErrorExtraInfo, ServiceError } from "../error";
+
+import { type LoginProviderType, type UserData } from "./models";
+
+export class OAuthFailure extends ServiceError {
+    constructor(provider: LoginProviderType, extra?: ErrorExtraInfo) {
+        super("Authentication failed", {
+            shouldCapture: false,
+            details: {
+                provider,
+                ...extra?.details,
+            },
+            reason: extra?.reason,
+        });
+    }
+}
+
+export class UserNotInvited extends ServiceError {
+    constructor(provider: LoginProviderType, userData: UserData) {
+        super("User not invited", {
+            details: {
+                provider,
+                userData,
+            },
+        });
+    }
+}
+
+export class AuthRequestNotFound extends ServiceError {
+    constructor(code: string) {
+        super(
+            "Auth request not found",
+            {
+                shouldCapture: false,
+                details: {
+                    code,
+                },
+            }
+        );
+    }
+}

--- a/webapp/src/backend/service/auth/github.ts
+++ b/webapp/src/backend/service/auth/github.ts
@@ -1,0 +1,78 @@
+import { createOAuthUserAuth as createGithubUserAuth } from "@octokit/auth-oauth-user";
+import { Octokit as GithubAuthClient } from "@octokit/core";
+
+import { config } from "../../../config/backend";
+
+import { OAuthFailure } from "./errors";
+import {
+    type AuthResult,
+    type LoginOptions,
+    type UserData,
+    LoginProviderType,
+} from "./models";
+import { authenticateUser } from "./utils";
+
+const GITHUB_REDIRECT_URI = `${config.APP_BASE_URL}${config.GITHUB_LOGIN_PATH}`;
+
+export function getGithubAuthUrl(state: string, { error }: { error?: string; }): string {
+    if (error) {
+        const errorUrl = new URL(`${config.APP_BASE_URL}/login`);
+        errorUrl.searchParams.append("error", `github_${error}`);
+        return errorUrl.toString();
+    }
+    const url = new URL("https://github.com/login/oauth/authorize");
+
+    url.searchParams.append("client_id", config.GITHUB_CLIENT_ID);
+    url.searchParams.append("scope", "read:user user:email");
+    url.searchParams.append("redirect_uri", GITHUB_REDIRECT_URI);
+
+    if (state) {
+        url.searchParams.append("state", state);
+    }
+
+    return url.toString();
+}
+
+export async function authGithubUser(authCode: string, { isCliSession = false }: LoginOptions): Promise<AuthResult> {
+    try {
+        const githubUserAuth = createGithubUserAuth({
+            clientId: config.GITHUB_CLIENT_ID,
+            clientSecret: config.GITHUB_CLIENT_SECRET,
+            code: authCode,
+            redirectUrl: GITHUB_REDIRECT_URI,
+        });
+
+        const { token: auth } = await githubUserAuth();
+        const octokit = new GithubAuthClient({ auth });
+
+        const [{ data: userProfile }, { data: userEmails }] = await Promise.all([
+            octokit.request("GET /user"),
+            octokit.request("GET /user/emails"),
+        ]);
+
+        const verifiedEmails = userEmails.filter(e => e.verified).map(e => ({ email: e.email, primary: e.primary }));
+        const emails = verifiedEmails.map(e => e.email);
+        const primaryEmail = verifiedEmails.find(({ primary }) => primary)?.email ?? emails[0];
+
+        const userData: UserData = {
+            loginProvider: LoginProviderType.Github,
+            email: primaryEmail,
+            emails,
+            externalId: userProfile.id.toString(),
+        };
+
+        if (userProfile.name) {
+            userData.fullName = userProfile.name;
+        }
+
+        if (userProfile.avatar_url) {
+            userData.avatarUrl = userProfile.avatar_url;
+        }
+
+        return authenticateUser(userData, { isCliSession });
+    } catch (err) {
+        throw new OAuthFailure(LoginProviderType.Github, {
+            reason: err as Error,
+        });
+    }
+}

--- a/webapp/src/backend/service/auth/gitlab.ts
+++ b/webapp/src/backend/service/auth/gitlab.ts
@@ -2,14 +2,14 @@ import fetch from "node-fetch";
 
 import { config } from "../../../config/backend";
 
+import { OAuthFailure } from "./errors";
 import {
     type AuthResult,
-    authenticateUser,
     type LoginOptions,
-    OAuthFailure,
     type UserData,
-} from "./auth";
-import { LoginProviderType } from "./models";
+    LoginProviderType,
+} from "./models";
+import { authenticateUser } from "./utils";
 
 const GITLAB_REDIRECT_URI = `${config.APP_BASE_URL}${config.GITLAB_LOGIN_PATH}`;
 

--- a/webapp/src/backend/service/auth/google.ts
+++ b/webapp/src/backend/service/auth/google.ts
@@ -1,0 +1,82 @@
+import { OAuth2Client as GoogleAuthClient } from "google-auth-library";
+import { decode as jwtDecode } from "jsonwebtoken";
+
+import { config } from "../../../config/backend";
+
+import { OAuthFailure } from "./errors";
+import {
+    type AuthResult,
+    type LoginOptions,
+    type UserData,
+    LoginProviderType,
+} from "./models";
+import { authenticateUser } from "./utils";
+
+const GOOGLE_REDIRECT_URI = `${config.APP_BASE_URL}${config.GOOGLE_LOGIN_PATH}`;
+
+function getGoogleClient(): GoogleAuthClient {
+    return new GoogleAuthClient(
+        config.GOOGLE_CLIENT_ID,
+        config.GOOGLE_CLIENT_SECRET,
+        GOOGLE_REDIRECT_URI
+    );
+}
+
+export function getGoogleAuthUrl(state: string): string {
+    const oAuth2Client = getGoogleClient();
+
+    return oAuth2Client.generateAuthUrl({
+        prompt: "select_account",
+        access_type: "offline",
+        scope: [
+            "https://www.googleapis.com/auth/userinfo.profile",
+            "https://www.googleapis.com/auth/userinfo.email",
+        ],
+        state,
+    });
+}
+
+interface GoogleIdPayload {
+    iss: string;
+    aud: string;
+    sub: string;
+    email: string;
+    email_verified: boolean;
+    name?: string;
+    picture?: string;
+    given_name?: string;
+    family_name?: string;
+    iat: number;
+    exp: number;
+}
+
+function decodeGoogleIdToken(idToken: string): GoogleIdPayload {
+    return jwtDecode(idToken) as GoogleIdPayload;
+}
+
+export async function authGoogleUser(authCode: string, { isCliSession = false }: LoginOptions): Promise<AuthResult> {
+    try {
+        const oAuth2Client = getGoogleClient();
+        const response = await oAuth2Client.getToken(authCode);
+        const idToken = response.tokens.id_token;
+
+        if (!idToken) {
+            throw new OAuthFailure(LoginProviderType.Google);
+        }
+
+        const idPayload = decodeGoogleIdToken(idToken);
+        const userData: UserData = {
+            loginProvider: LoginProviderType.Google,
+            email: idPayload.email,
+            externalId: idPayload.sub,
+            fullName: [idPayload.given_name ?? "", idPayload.family_name ?? ""].join(" "),
+            avatarUrl: idPayload.picture,
+        };
+
+        return authenticateUser(userData, { isCliSession });
+    } catch (err) {
+        throw new OAuthFailure(LoginProviderType.Google, {
+            reason: err as Error,
+        });
+    }
+}

--- a/webapp/src/backend/service/auth/models.ts
+++ b/webapp/src/backend/service/auth/models.ts
@@ -1,4 +1,7 @@
+import { type JwtPayload } from "jsonwebtoken";
 import { type Types, model, Schema } from "mongoose";
+
+import { type User } from "../user/user";
 
 const AUTH_REQUEST_COLLECTION_NAME = "authRequests";
 
@@ -7,6 +10,34 @@ export enum LoginProviderType {
     Github = "github",
     Gitlab = "gitlab",
     Email = "email",
+}
+
+export interface LoginOptions {
+    isCliSession: boolean;
+}
+
+export interface UserData {
+    email: string;
+    emails?: string[];
+    fullName?: string;
+    avatarUrl?: string;
+    loginProvider: LoginProviderType;
+    externalId: string;
+}
+
+export type AuthToken = string;
+
+export interface AuthResult {
+    user: User;
+    token: AuthToken;
+    isNewUser: boolean;
+}
+
+export interface TokenPayload extends JwtPayload {
+    userId: string;
+    email: string;
+    loginProvider: LoginProviderType;
+    isAdmin?: boolean;
 }
 
 export interface AuthRequestDoc {
@@ -43,4 +74,5 @@ const AuthRequestSchema = new Schema<AuthRequestDoc>({
         virtuals: true,
     },
 });
+
 export const AuthRequestModel = model<AuthRequestDoc>("AuthRequest", AuthRequestSchema, AUTH_REQUEST_COLLECTION_NAME);

--- a/webapp/src/backend/service/auth/utils.ts
+++ b/webapp/src/backend/service/auth/utils.ts
@@ -1,0 +1,129 @@
+import {
+    type Algorithm as JwtAlgorithm,
+    type SignOptions as JwtSignOptions,
+    sign as jwtSign,
+} from "jsonwebtoken";
+
+import { config } from "../../../config/backend";
+import {
+    type User,
+    createUser,
+    createUserSession as createSession,
+    findUserByEmail,
+    findUserByLoginProvider,
+    isAdminUser,
+    linkExternalAccount,
+} from "../user/user";
+import {
+    addMember,
+    findWorkspaceInvitesByEmail,
+    markInviteAsUsed,
+    removeMember,
+} from "../workspace/workspace";
+
+import { UserNotInvited } from "./errors";
+import {
+    type AuthResult,
+    type AuthToken,
+    type LoginProviderType,
+    type TokenPayload,
+    type UserData,
+} from "./models";
+
+async function registerUser(userData: UserData): Promise<User> {
+    const user = await createUser({
+        email: userData.email,
+        fullName: userData.fullName,
+        avatarUrl: userData.avatarUrl,
+        loginProvider: userData.loginProvider,
+        externalId: userData.externalId,
+    });
+
+    return user;
+}
+
+async function acceptUserInvites(user: User) {
+    const loginProvider = user.loginProviders[0].type;
+    const userData = {
+        email: user.email,
+        fullName: user.fullName,
+        avatarUrl: user.avatarUrl,
+        loginProvider,
+        externalId: user.loginProviders[0].externalId,
+    };
+
+    const invites = await findWorkspaceInvitesByEmail(user.email);
+    if (!invites) {
+        throw new UserNotInvited(loginProvider, userData);
+    }
+
+    for (const invite of invites) {
+        if (invite.expiresAt.getTime() < Date.now() || invite.isUsed) {
+            continue;
+        }
+
+        try {
+            await addMember(invite.workspaceId, user.id);
+            await markInviteAsUsed(invite.code, user.id);
+        } catch (error) {
+            await removeMember(invite.workspaceId, user.id);
+
+            continue;
+        }
+    }
+}
+
+
+export function generateUserToken(tokenId: string, payload: TokenPayload, isCliSession: boolean): AuthToken {
+    const signOptions: JwtSignOptions = {
+        jwtid: tokenId,
+        expiresIn: isCliSession ? config.JWT_EXPIRY_CLI : config.JWT_EXPIRY,
+        algorithm: config.JWT_ALGO as JwtAlgorithm,
+        issuer: config.JWT_ISSUER,
+    };
+    const token = jwtSign(payload, config.JWT_PRIVATE_KEY, signOptions);
+
+    return token;
+}
+
+export async function createUserSession(user: User, loginProvider: LoginProviderType, { isCliSession }: { isCliSession: boolean; }): Promise<AuthToken> {
+    const [session, isAdmin] = await Promise.all([
+        createSession(user.id, loginProvider),
+        isAdminUser(user.id),
+    ]);
+    const payload = {
+        userId: user.id,
+        email: user.email,
+        isAdmin,
+        loginProvider,
+    };
+
+    return generateUserToken(session.id, payload, isCliSession);
+}
+
+export async function authenticateUser(userData: UserData, { isCliSession }: { isCliSession: boolean; }): Promise<AuthResult> {
+    let user = await findUserByLoginProvider(userData.loginProvider, userData.externalId);
+    let isNewUser = false;
+
+    if (!user) {
+        user = await findUserByEmail(userData.emails ?? userData.email);
+
+        if (user) {
+            await linkExternalAccount(user.id, userData.loginProvider, userData.externalId);
+        } else {
+            user = await registerUser(userData);
+
+            isNewUser = true;
+        }
+    }
+
+    try {
+        await acceptUserInvites(user);
+    } catch (error) {
+        // Silently ignore unhandled invites
+    }
+
+    const token = await createUserSession(user, userData.loginProvider, { isCliSession });
+
+    return { user, token, isNewUser };
+}

--- a/webapp/tests/helper/auth.ts
+++ b/webapp/tests/helper/auth.ts
@@ -1,7 +1,7 @@
 import { type Response } from "superagent";
 
-import { generateUserToken } from "../../src/backend/service/auth/auth";
 import { type LoginProviderType } from "../../src/backend/service/auth/models";
+import { generateUserToken } from "../../src/backend/service/auth/utils";
 import { generateNanoId } from "../../src/backend/service/utils";
 import { config } from "../../src/config/backend";
 


### PR DESCRIPTION
Follow-up for #7. 

- Move auth provides to their own files
- Prevent cyclical dependencies.