### PR TITLE
[Issue#2] Add subcomponents detection and dashboard integration

### DIFF
--- a/docs/dashboard/components/README.md
+++ b/docs/dashboard/components/README.md
@@ -4,7 +4,7 @@ The Components page lists all your components, where you can [search and filter]
 
 ![Components page](../../images/components-page.png)
 
-You can also get deeper insights into individual components: see the [Dependency tree](./dependency-tree.md) to understand relationships, and [Props tracking](./props-tracking.md) to see how each prop is used.
+You can also get deeper insights into individual components: see the [Dependency tree](./dependency-tree.md) to understand relationships, [Props tracking](./props-tracking.md) to see how each prop is used, and [Subcomponents](./subcomponents.md) to explore component families.
 
 ## Sections
 
@@ -12,6 +12,7 @@ You can also get deeper insights into individual components: see the [Dependency
 - [Component tags](./tags.md)
 - [Dependency tree](./dependency-tree.md)
 - [Props tracking](./props-tracking.md)
+- [Subcomponents](./subcomponents.md)
 
 ---
 

--- a/docs/dashboard/components/props-tracking.md
+++ b/docs/dashboard/components/props-tracking.md
@@ -30,4 +30,4 @@ Under **Popular Charts**, Omlet displays unused component props that can be remo
 
 ---
 
-← [Dependency tree](./dependency-tree.md)
+← [Dependency tree](./dependency-tree.md) · [Subcomponents](./subcomponents.md) →

--- a/docs/dashboard/components/subcomponents.md
+++ b/docs/dashboard/components/subcomponents.md
@@ -1,0 +1,17 @@
+# Subcomponents
+
+The **Subcomponents** tab on the **Component Detail** page lists all subcomponents belonging to a component family — components that share the same root name and package as the selected component.
+
+For example, if a design system exports `Button.Primary`, `Button.Secondary`, and `Button.Link`, visiting the detail page for `Button` shows these as subcomponents.
+
+## View subcomponents
+
+Open the **Subcomponents** tab on a component's detail page to see the list. Each row shows the subcomponent name and how many times it is used across projects. Click a subcomponent to open its detail page.
+
+## Family usage
+
+The component detail panel also shows **# Root component used**, which reflects the total usage of the component family (the root component plus all of its subcomponents).
+
+---
+
+← [Props tracking](./props-tracking.md)

--- a/docs/dashboard/components/subcomponents.md
+++ b/docs/dashboard/components/subcomponents.md
@@ -10,7 +10,7 @@ Open the **Subcomponents** tab on a component's detail page to see the list. Eac
 
 ## Family usage
 
-The component detail panel also shows **# Root component used**, which reflects the total usage of the component family (the root component plus all of its subcomponents).
+The component detail panel also shows **# Root used**, which reflects the total usage of the component family (the root component plus all of its subcomponents).
 
 ---
 

--- a/webapp/src/backend/router/api.ts
+++ b/webapp/src/backend/router/api.ts
@@ -41,6 +41,7 @@ import {
     analyseTimeSeriesDataAsCSV,
     findLatestComponentsByDefinitionId,
     getComponentProps,
+    getComponentSubcomponents,
     getComponentUsagesWithParentComponent,
     getCustomProperties,
     getDependenciesFor,
@@ -1726,6 +1727,73 @@ apiRouter.get("/workspaces/:workspaceSlug/components/:definitionId/props",
         } catch (error) {
             if (error instanceof WorkspaceNotFound || error instanceof MemberNotFound) {
                 throw new ClientError(httpStatus.NOT_FOUND, ErrorResponseCode.WORKSPACE_NOT_FOUND);
+            }
+
+            throw error;
+        }
+    }
+);
+
+apiRouter.get("/workspaces/:workspaceSlug/components/:definitionId/subcomponents",
+    authMiddleware({ credentialsRequired: false }),
+    requestValidator({
+        params: {
+            schema: joi.object({
+                workspaceSlug: joi.string(),
+                definitionId: joi.string(),
+            }),
+        },
+    }),
+    async (req: Request<{ workspaceSlug: string; definitionId: string; }>, res: Response) => {
+        try {
+            const {
+                auth,
+                params: {
+                    workspaceSlug,
+                    definitionId,
+                },
+            } = req;
+
+            const workspace = await getWorkspaceIfAuthorized(workspaceSlug, UserPermission.READ, { auth });
+
+            const dataRevisionId = await getWorkspaceDataRevisionId(workspace.id);
+            const computedEtag = etag(JSON.stringify({
+                cacheVersion: COMPONENTS_ETAG_CACHE_VERSION,
+                workspaceId: workspace.id,
+                dataRevisionId,
+                definitionId,
+                url: req.originalUrl,
+            }));
+
+            const clientEtag = req.get("If-None-Match");
+            if (clientEtag === computedEtag) {
+                return res.status(httpStatus.NOT_MODIFIED)
+                    .set("ETag", computedEtag)
+                    .set("Cache-Control", "private")
+                    .set("Content-Type", "application/json")
+                    .send();
+            }
+
+            const { subcomponents, familyUsage } = await getComponentSubcomponents(workspace.id, definitionId);
+            const projectMap = Object.fromEntries(workspace.projects.map(p => [p.packageName, p]));
+            subcomponents.forEach(component => {
+                component.packageName = projectMap[component.packageName]?.alias || component.packageName;
+            });
+
+            res.status(httpStatus.OK)
+                .set("ETag", computedEtag)
+                .set("Cache-Control", "private")
+                .json({
+                    subcomponents: subcomponents.map(component => component.toResponse()),
+                    familyUsage,
+                });
+        } catch (error) {
+            if (error instanceof WorkspaceNotFound || error instanceof MemberNotFound) {
+                throw new ClientError(httpStatus.NOT_FOUND, ErrorResponseCode.WORKSPACE_NOT_FOUND);
+            }
+
+            if (error instanceof ComponentNotFound) {
+                throw new ClientError(httpStatus.NOT_FOUND, ErrorResponseCode.COMPONENT_NOT_FOUND);
             }
 
             throw error;

--- a/webapp/src/backend/service/component/component.ts
+++ b/webapp/src/backend/service/component/component.ts
@@ -740,6 +740,88 @@ export async function findLatestComponentsByDefinitionId(workspaceId: string, de
     return result.map(doc => Component.fromAggregationResult(doc));
 }
 
+export async function getComponentSubcomponents(
+    workspaceId: string,
+    componentDefinitionId: string,
+): Promise<{ subcomponents: Component[]; familyUsage: number; }> {
+    const latestAnalysisId = await getLatestIndexAnalysisId(workspaceId);
+    if (!latestAnalysisId) {
+        return { subcomponents: [], familyUsage: 0 };
+    }
+
+    const [parent] = await findLatestComponentsByDefinitionId(workspaceId, [componentDefinitionId]);
+    if (!parent) {
+        throw new ComponentNotFound();
+    }
+
+    const escapedName = escapeRegex(parent.name);
+    const regexPattern = new RegExp(`^${escapedName}\\.`);
+
+    const result = await HistoricComponentIndexModel.aggregate<ComponentAggregationResult>([
+        {
+            $match: {
+                workspace: new MongooseTypes.ObjectId(workspaceId),
+                lastAnalysis: new MongooseTypes.ObjectId(latestAnalysisId),
+            },
+        },
+        {
+            $unwind: {
+                path: "$entries",
+            },
+        },
+        {
+            $match: {
+                "entries.definitionId": { $ne: componentDefinitionId },
+                "entries.component.name": regexPattern,
+                "entries.component.packageName": parent.packageName,
+            },
+        },
+        {
+            $addFields: {
+                "entries.component.numOfUsages": {
+                    $size: "$entries.usingComponents",
+                },
+                "entries.component.tags": "$entries.tags",
+                "entries.component.lastUsageChangedAt": "$entries.lastUsageChangedAt",
+            },
+        },
+        {
+            $replaceRoot: {
+                newRoot: {
+                    $mergeObjects: [
+                        "$entries.component",
+                        {
+                            id: "$entries.component._id",
+                            tags: {
+                                $cond: {
+                                    if: { $eq: ["$entries.component.isInternal", false] },
+                                    then: {
+                                        $concatArrays: ["$entries.tags", [RESERVED_TAGS.EXTERNAL.slug]],
+                                    },
+                                    else: "$entries.tags",
+                                },
+                            },
+                            numOfUsages: {
+                                $size: "$entries.usingComponents",
+                            },
+                        },
+                    ],
+                },
+            },
+        },
+        {
+            $sort: {
+                name: 1,
+            },
+        },
+    ], {});
+
+    const subcomponents = result.map(doc => Component.fromAggregationResult(doc));
+    const familyUsage = parent.numOfUsages + subcomponents.reduce((sum, c) => sum + c.numOfUsages, 0);
+
+    return { subcomponents, familyUsage };
+}
+
 export class CustomPropertyRequiredForAnalysis extends ServiceError {
     constructor() {
         super("Custom property value required for given analysis subject");

--- a/webapp/src/frontend/api/api.ts
+++ b/webapp/src/frontend/api/api.ts
@@ -457,6 +457,20 @@ export async function getLatestAnalysisComponentProps(workspaceSlug: string, com
     return handleResponse<ComponentProps>(response);
 }
 
+interface SubcomponentsResponse {
+    subcomponents: RawComponent[];
+    familyUsage: number;
+}
+
+export async function getLatestAnalysisComponentSubcomponents(workspaceSlug: string, componentId: string): Promise<{ subcomponents: Component[]; familyUsage: number; }> {
+    const response = await http.get(`${base}/workspaces/${workspaceSlug}/components/${componentId}/subcomponents`);
+    const { subcomponents, familyUsage } = await handleResponse<SubcomponentsResponse>(response);
+    return {
+        subcomponents: subcomponents.map(transformComponent),
+        familyUsage,
+    };
+}
+
 export async function getMembers(workspaceSlug: string): Promise<Member[]> {
     const response = await http.get(`${base}/workspaces/${workspaceSlug}/members`);
     return handleResponse<Member[]>(response);

--- a/webapp/src/frontend/pages/componentDetail/ComponentDetail.tsx
+++ b/webapp/src/frontend/pages/componentDetail/ComponentDetail.tsx
@@ -277,7 +277,7 @@ export function ComponentDetail() {
                                     <>
                                         <IconComponents />
                                         <div>
-                                            Subcomponents
+                                            Subcomponents ({subcomponents?.length ?? 0})
                                         </div>
                                     </>
                                 ),

--- a/webapp/src/frontend/pages/componentDetail/ComponentDetail.tsx
+++ b/webapp/src/frontend/pages/componentDetail/ComponentDetail.tsx
@@ -9,7 +9,9 @@ import {
     getLatestAnalysisComponent,
     getLatestAnalysisComponentDependencies,
     getLatestAnalysisComponentProps,
+    getLatestAnalysisComponentSubcomponents,
 } from "../../api/api";
+import { IconComponents } from "../../library/icons/IconComponents";
 import { IconDependencyTree } from "../../library/icons/IconDependencyTree";
 import { IconProps } from "../../library/icons/IconProps";
 import { logError } from "../../logger";
@@ -20,6 +22,7 @@ import { useStore } from "../../providers/StoreProvider/StoreProvider";
 import { ComponentDetailInfo } from "./componentDetailInfo/ComponentDetailInfo";
 import { PropsTable } from "./propsTable/PropsTable";
 import { PropUsages } from "./propUsages/PropUsages";
+import { SubcomponentsTable } from "./subcomponentsTable/SubcomponentsTable";
 import { Tabs } from "./tabs/Tabs";
 import { TreeViewWithReactFlowProvider as TreeView } from "./treeView/TreeView";
 
@@ -82,6 +85,8 @@ export function ComponentDetail() {
     const workspace = getWorkspace()!;
 
     const [component, setComponent] = useState<Component | undefined>(undefined);
+    const [subcomponents, setSubcomponents] = useState<Component[] | undefined>(undefined);
+    const [familyUsage, setFamilyUsage] = useState<number | undefined>(undefined);
     const [, definitionId] = useMemo(() => componentSlug?.split("::") ?? [], [componentSlug]);
 
     const { data: customProperties } = useQuery({
@@ -94,6 +99,20 @@ export function ComponentDetail() {
             );
         },
     });
+
+    const detailInfoCustomProperties = useMemo(() => {
+        if (!customProperties) {
+            return undefined;
+        }
+        const result: Record<string, (string | number | boolean | Date)[]> = { ...customProperties };
+        if (subcomponents !== undefined) {
+            result.subcomponents = [subcomponents.length];
+        }
+        if (familyUsage !== undefined) {
+            result.rootComponent = [familyUsage];
+        }
+        return result;
+    }, [customProperties, familyUsage, subcomponents]);
 
     useEffect(() => {
         if (activeTab === "dependency-tree" || componentProps?.definitionId === definitionId) {
@@ -127,6 +146,21 @@ export function ComponentDetail() {
             }
         }
         fetchComponent();
+    }, [workspace, definitionId]);
+
+    useEffect(() => {
+        async function fetchSubcomponents() {
+            try {
+                const { subcomponents, familyUsage } = await getLatestAnalysisComponentSubcomponents(workspaceSlug!, encodeURIComponent(definitionId));
+                setSubcomponents(subcomponents);
+                setFamilyUsage(familyUsage);
+            } catch (error) {
+                logError(error);
+            }
+        }
+        setSubcomponents(undefined);
+        setFamilyUsage(undefined);
+        fetchSubcomponents();
     }, [workspace, definitionId]);
 
     useEffect(() => {
@@ -208,7 +242,7 @@ export function ComponentDetail() {
             <div className={classes.leftPanel}>
                 <ComponentDetailInfo
                     component={component}
-                    customProperties={customProperties}/>
+                    customProperties={detailInfoCustomProperties}/>
             </div>
             {(
                 selectedProp
@@ -235,6 +269,23 @@ export function ComponentDetail() {
                                         props={componentProps?.data.props ?? []}
                                         numberOfUsages={componentProps?.data.numberOfUsages ?? 0}
                                         onPropClick={handlePropClick} />
+                                ),
+                            },
+                            {
+                                key: "subcomponents",
+                                label: (
+                                    <>
+                                        <IconComponents />
+                                        <div>
+                                            Subcomponents
+                                        </div>
+                                    </>
+                                ),
+                                content: (
+                                    <SubcomponentsTable
+                                        loading={subcomponents === undefined}
+                                        subcomponents={subcomponents ?? []}
+                                        workspaceSlug={workspaceSlug!} />
                                 ),
                             },
                             {

--- a/webapp/src/frontend/pages/componentDetail/componentDetailInfo/ComponentDetailInfo.tsx
+++ b/webapp/src/frontend/pages/componentDetail/componentDetailInfo/ComponentDetailInfo.tsx
@@ -98,6 +98,9 @@ export function ComponentDetailInfo({ component, customProperties }: Props) {
     const tags = getTags().filter(({ slug }) => tagSlugs.has(slug));
     const spacedPath = path.split("/").join(`/${ZERO_WIDTH_SPACE}`);
 
+    const rootComponentUsage = customProperties?.rootComponent?.[0] as number | undefined;
+    const subcomponentsCount = customProperties?.subcomponents?.[0] as number | undefined;
+
     const birthday = (() => {
         if (!createdAt) {
             return null;
@@ -139,8 +142,14 @@ export function ComponentDetailInfo({ component, customProperties }: Props) {
             return null;
         }
 
-        const customPropertyNames = Object.keys(customProperties);
-        const customPropertyTypes = getCustomPropertyTypes(customProperties);
+        const filteredCustomProperties = Object.fromEntries(
+            Object.entries(customProperties).filter(([key]) => key !== "rootComponent" && key !== "subcomponents"),
+        );
+        const customPropertyNames = Object.keys(filteredCustomProperties);
+        if (customPropertyNames.length === 0) {
+            return null;
+        }
+        const customPropertyTypes = getCustomPropertyTypes(filteredCustomProperties);
 
         return (
             <section>
@@ -149,7 +158,7 @@ export function ComponentDetailInfo({ component, customProperties }: Props) {
                     <span>CUSTOM PROPERTIES</span>
                 </H4>
                 {customPropertyNames.map(name =>
-                    <ComponentField key={name} name={name} type={customPropertyTypes[name]} value={metadata[name]}/>
+                    <ComponentField key={name} name={name} type={customPropertyTypes[name]} value={metadata[name]}/>,
                 )}
             </section>
         );
@@ -177,7 +186,13 @@ export function ComponentDetailInfo({ component, customProperties }: Props) {
                     <IconChild/>
                     <span>{numOfDependencies}</span>
                 </ComponentField>
+                {subcomponentsCount !== undefined && (
+                    <ComponentField name="# subcomponents" value={subcomponentsCount}/>
+                )}
                 <ComponentField name="# Used" value={numOfUsages}/>
+                {rootComponentUsage !== undefined && (
+                    <ComponentField name="# Root component used" value={rootComponentUsage}/>
+                )}
                 <ComponentField
                     name="Created"
                     value={createdAt ? formatDate(createdAt) : "Over a year"}

--- a/webapp/src/frontend/pages/componentDetail/componentDetailInfo/ComponentDetailInfo.tsx
+++ b/webapp/src/frontend/pages/componentDetail/componentDetailInfo/ComponentDetailInfo.tsx
@@ -99,7 +99,6 @@ export function ComponentDetailInfo({ component, customProperties }: Props) {
     const spacedPath = path.split("/").join(`/${ZERO_WIDTH_SPACE}`);
 
     const rootComponentUsage = customProperties?.rootComponent?.[0] as number | undefined;
-    const subcomponentsCount = customProperties?.subcomponents?.[0] as number | undefined;
 
     const birthday = (() => {
         if (!createdAt) {
@@ -186,12 +185,9 @@ export function ComponentDetailInfo({ component, customProperties }: Props) {
                     <IconChild/>
                     <span>{numOfDependencies}</span>
                 </ComponentField>
-                {subcomponentsCount !== undefined && (
-                    <ComponentField name="# subcomponents" value={subcomponentsCount}/>
-                )}
                 <ComponentField name="# Used" value={numOfUsages}/>
                 {rootComponentUsage !== undefined && (
-                    <ComponentField name="# Root component used" value={rootComponentUsage}/>
+                    <ComponentField name="# Root used" value={rootComponentUsage}/>
                 )}
                 <ComponentField
                     name="Created"

--- a/webapp/src/frontend/pages/componentDetail/subcomponentsTable/SubcomponentsTable.module.css
+++ b/webapp/src/frontend/pages/componentDetail/subcomponentsTable/SubcomponentsTable.module.css
@@ -1,0 +1,92 @@
+.subcomponentsTable {
+    padding: 0 var(--spacing-xs);
+    display: grid;
+    grid-template-columns: 1fr max-content;
+    overflow: auto;
+}
+
+.subcomponentsTable .header {
+    display: contents;
+}
+
+.subcomponentsTable .header .cell {
+    position: sticky;
+    top: 0;
+    display: flex;
+    align-items: center;
+    font-weight: 600;
+    height: 43px;
+    gap: 6px;
+    background-color: var(--background-primary-color);
+    z-index: 1;
+    color: var(--label-primary-color);
+    font-size: 13px;
+    line-height: 18px;
+}
+
+.subcomponentsTable .header .cell:first-child {
+    padding: 0 var(--spacing-xxl-2) 0 var(--spacing-s);
+    border-radius: var(--spacing-xxs) 0 0 var(--spacing-xxs);
+}
+
+.subcomponentsTable .header .cell:last-child {
+    padding: 0 var(--spacing-s) 0 var(--spacing-xxl-2);
+    justify-content: flex-end;
+    border-radius: 0 var(--spacing-xxs) var(--spacing-xxs) 0;
+}
+
+.subcomponentsTable .row {
+    display: contents;
+}
+
+.subcomponentsTable .row .cell {
+    display: flex;
+    align-items: center;
+    height: 56px;
+    gap: var(--spacing-m);
+    font-size: 13px;
+    color: var(--label-primary-color);
+    padding: 0 var(--spacing-xxl-2) 0 var(--spacing-s);
+}
+
+.subcomponentsTable .row .cell:first-child {
+    padding: 0 var(--spacing-xxl-2) 0 var(--spacing-s);
+    font-family: var(--font-family-secondary);
+}
+
+.subcomponentsTable .row .cell:last-child {
+    padding: 0 var(--spacing-s) 0 var(--spacing-xxl-2);
+    justify-content: flex-end;
+}
+
+.subcomponentsTable .row .cell:hover {
+    text-decoration: none;
+}
+
+.subcomponentsTable .row:hover .cell {
+    background-color: var(--background-tertiary-color);
+}
+
+.subcomponentsTable .row .separator {
+    grid-column: span 2;
+    height: var(--border-width);
+    background-color: var(--border-primary-color);
+    margin: 0 var(--spacing-s);
+}
+
+.subcomponentsTable .row:hover+.row .separator,
+.subcomponentsTable .row:hover .separator {
+    background: none;
+}
+
+.subcomponentsTable.loading .row .cell .skeleton {
+    height: var(--spacing-s);
+}
+
+.subcomponentsTable.loading .row .cell:first-child .skeleton {
+    width: 160px;
+}
+
+.subcomponentsTable.loading .row .cell:last-child .skeleton {
+    width: 32px;
+}

--- a/webapp/src/frontend/pages/componentDetail/subcomponentsTable/SubcomponentsTable.tsx
+++ b/webapp/src/frontend/pages/componentDetail/subcomponentsTable/SubcomponentsTable.tsx
@@ -1,0 +1,76 @@
+import classNames from "classnames";
+import { Link, generatePath } from "react-router-dom";
+
+import { RoutePath } from "../../../../common/RoutePath";
+import { EmptyBlock } from "../../../common/EmptyBlock/EmptyBlock";
+import { Skeleton } from "../../../library/Skeleton/Skeleton";
+import { type Component } from "../../../models/Component";
+import { range } from "../../../utils";
+
+import classes from "./SubcomponentsTable.module.css";
+
+interface Props {
+    loading: boolean;
+    subcomponents: Component[];
+    workspaceSlug: string;
+}
+
+export function SubcomponentsTable({ loading, subcomponents, workspaceSlug }: Props) {
+    if (loading) {
+        return (
+            <div className={classNames(classes.subcomponentsTable, classes.loading)}>
+                <div className={classes.header}>
+                    <div className={classes.cell}>Name</div>
+                    <div className={classes.cell}># Used</div>
+                </div>
+                {[...range(1, 5)].map(i => (
+                    <div className={classes.row} key={i}>
+                        {i > 1 && <div className={classes.separator} />}
+                        <div className={classes.cell}>
+                            <Skeleton className={classes.skeleton} />
+                        </div>
+                        <div className={classes.cell}>
+                            <Skeleton className={classes.skeleton} />
+                        </div>
+                    </div>
+                ))}
+            </div>
+        );
+    }
+
+    if (subcomponents.length === 0) {
+        return (
+            <EmptyBlock
+                message="No subcomponents found for this component."
+            />
+        );
+    }
+
+    return (
+        <div className={classes.subcomponentsTable}>
+            <div className={classes.header}>
+                <div className={classes.cell}>Name</div>
+                <div className={classes.cell}># Used</div>
+            </div>
+            {subcomponents.map(({ name, definitionId, numOfUsages }, i) => {
+                const componentSlug = encodeURIComponent(`${name}::${definitionId}`);
+                const to = generatePath(RoutePath.ComponentDetail, {
+                    workspaceSlug,
+                    componentSlug,
+                });
+
+                return (
+                    <div className={classes.row} key={definitionId}>
+                        {i > 0 && <div className={classes.separator} />}
+                        <Link className={classes.cell} to={to}>
+                            {name}
+                        </Link>
+                        <div className={classes.cell}>
+                            {numOfUsages}
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}


### PR DESCRIPTION
Github issue: https://github.com/zeplin/omlet/issues/2

This PR introduces a **Subcomponents** tab on the Component Detail page, allowing users to discover and navigate component families (e.g., `Button.Primary`, `Button.Secondary`). It also surfaces the total family usage in the component info panel.

### Changes
- **Backend**
  - New API endpoint: `GET /workspaces/:workspaceSlug/components/:definitionId/subcomponents`
  - New service `getComponentSubcomponents` that finds components matching `^Name\.` in the same package and aggregates their usage
  - Computes `familyUsage` as the sum of the root component's usages plus all subcomponent usages
- **Frontend**
  - Added `SubcomponentsTable` with loading skeletons, empty state, and links to subcomponent detail pages
  - Integrated tab into `ComponentDetail` with subcomponent counter
  - Updated `ComponentDetailInfo` to display `# Root used`
- **Docs**
  - Added `docs/dashboard/components/subcomponents.md`
  - Updated Components overview and navigation links

**Component details**
<img width="1917" height="449" alt="img-2" src="https://github.com/user-attachments/assets/7c65e761-366f-4791-9e62-5c22c096acb0" />

**Component overview**
<img width="1915" height="390" alt="img-1" src="https://github.com/user-attachments/assets/60e9c005-e03f-4830-b88f-86057765243c" />


### How to test
1. Open any component detail page that has subcomponents (e.g., `Button`)
2. Verify the **Subcomponents** tab appears between **Props** and **Dependency tree**
3. Confirm the table lists subcomponent names and usage counts
4. Confirm the left panel shows  `# Root used`